### PR TITLE
Deploy website to Github Pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,14 @@ install:
   - make travis
 script:
   - make
+deploy:
+  - provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_AUTH_TOKEN
+    committer_from_gh: true
+    local_dir: public
+    repo: shipwright-io/shipwright-io.github.io
+    target_branch: master
+    keep_history: true
+    on:
+      branch: master

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@
 all: build
 
 build:
-	hugo --minify
+	rm -rf public/*
+	hugo -t docsy --minify
 
 travis:
 	hack/install-hugo.sh
 	npm install
-	


### PR DESCRIPTION
Use travis deployer to update the website when changes merge to the
primary branch. Note that Travis runs the build commands on every merge
to the primary branch.