### PR TITLE
Replace mailto links for Shipwright email lists

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -146,7 +146,7 @@ enable = false
 # End user relevant links. These will show up on left side of footer and in the community page if you have one.
 [[params.links.user]]
     name = "User mailing list"
-    url = "mailto:shipwright-users@lists.shipwright.io"
+    url = "https://lists.shipwright.io/admin/lists/shipwright-users.lists.shipwright.io/"
     icon = "fa fa-envelope"
     desc = "Discussion and help from your fellow users"
 # [[params.links.user]]
@@ -172,6 +172,6 @@ enable = false
     desc = "Chat with the Shipwright contributors"
 [[params.links.developer]]
     name = "Developer mailing list"
-    url = "mailto:shipwright-dev@lists.shipwright.io"
+    url = "https://lists.shipwright.io/admin/lists/shipwright-dev.lists.shipwright.io/"
     icon = "fa fa-envelope"
     desc = "Discuss development issues around the project"

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -16,7 +16,7 @@ Documentation can be found on GitHub at
 The Shipwright contributors would love to hear from you! You can reach us in the following forums:
 
 - Users can discuss help, feature requests, or potential bugs at [shipwright-users@lists.shipwright.io](https://lists.shipwright.io/archives/list/shipwright-users@lists.shipwright.io/).
-  Click [here](<mailto:shipwright-users-join@lists.shipwright.io?subject=Subscribe to shipwright-users>) to join.
+  Click [here](https://lists.shipwright.io/admin/lists/shipwright-users.lists.shipwright.io/) to join.
 - Contributors can discuss active development topics at [shipwright-dev@lists.shipwright.io](https://lists.shipwright.io/archives/list/shipwright-dev@lists.shipwright.io/).
-  Click [here](<mailto:shipwright-dev-join@lists.shipwright.io?subject=Subscribe to shipwright-dev>) to join.
+  Click [here](https://lists.shipwright.io/admin/lists/shipwright-dev.lists.shipwright.io/) to join.
 - We can also be reached on Kubernetes Slack: [#shipwright](https://kubernetes.slack.com/messages/shipwright)


### PR DESCRIPTION
Mailto links do not work well across some browser/OS combinations.
Replacing these with the admin lists page hyperlink, which includes a
Subscribe/Unsubscribe form that works for any modern web browser.