### PR TITLE
Update docs link to main README.md

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -9,7 +9,7 @@ menu:
 ---
 
 Documentation can be found on GitHub at
-[shipwright-io/build](https://github.com/shipwright-io/build/blob/master/docs/README.md).
+[shipwright-io/build](https://github.com/shipwright-io/build/blob/master/README.md).
 
 ## Contact Us
 


### PR DESCRIPTION
The docs/README.md link is a bit more involved than the main README, which I think will serve as a better introduction (especially after https://github.com/shipwright-io/build/issues/655)