### PR TITLE
Build v0.4.0 Announcement

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -34,9 +34,9 @@ Shipwright supports popular tools such as
 {{% blocks/feature icon="fab" %}}
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-ship" title="Release v0.3.0 Available!" %}}
+{{% blocks/feature icon="fa-ship" title="Release v0.4.0 Available!" %}}
 
-Our latest release is now available on <a href="https://github.com/shipwright-io/build/releases/tag/v0.3.0">GitHub</a> and <a href="https://quay.io/repository/shipwright/shipwright-operator?tab=tags">quay.io</a>.
+Our latest release is now available on <a href="https://github.com/shipwright-io/build/releases/tag/v0.4.0">GitHub</a> and <a href="https://quay.io/repository/shipwright/shipwright-operator?tab=tags">quay.io</a>.
 
 {{% /blocks/feature %}}
 

--- a/content/en/blog/releases/v0.4.0-release-notes.md
+++ b/content/en/blog/releases/v0.4.0-release-notes.md
@@ -1,0 +1,50 @@
+---
+title: "Build v0.4.0"
+date: 2021-04-06T13:58:13-04:00
+draft: false
+---
+
+Shipwright Build v0.4.0 can be found on GitHub at [shipwright-io/build v0.4.0](https://github.com/shipwright-io/build/releases/tag/v0.4.0).
+
+This release includes several breaking changes and is incompatible with previous versions of Shipwright Build.
+
+## Upgrade Instructions
+
+1. Install v0.4.0 using the release YAML manifest:
+
+   ```bash
+   $ kubectl apply -f https://github.com/shipwright-io/build/releases/download/v0.4.0/release.yaml
+   ```
+
+2. Download existing `Build`, `BuildStrategy`, and `ClusterBuildStrategy` objects from your cluster in YAML format.
+3. For each object, change the `apiVersion` from `build.dev/v1alpha1` to `shipwright.io/v1alpha1`.
+   Remove any identifiers and creation timestamps from the object's metadata.
+4. Run `kubectl apply -f` against each manifest to re-create the relevant object.
+
+## Uninstalling v0.3.0
+
+Once the desired Shipwright Build objects have been migrated to the new api group, you can remove v0.3.0 from your cluster:
+
+1. Delete the `build-operator` namespace:
+
+   ```bash
+   $ kubectl delete ns build-operator
+   ```
+
+2. (optional) Delete all `BuildRun`, `Build`, `BuildStrategy`, and `ClusterBuildStrategy` objects in the build.dev api group on the cluster:
+
+   ```bash
+   $ kubectl delete buildrun.build.dev --all --all-namespaces
+   $ kubectl delete build.build.dev --all --all-namespaces
+   $ kubectl delete buildstrategy.build.dev --all --all-namespaces
+   $ kubectl delete clusterbuildstrategy.build.dev --all
+   ```
+
+3. (optional) Delete the custom resource definitions for `BuildRun`, `Build`, `BuildStrategy`, and `ClusterBuildStrategy` in the build.dev api group:
+
+   ```bash
+   $ kubectl delete crd buildruns.build.dev
+   $ kubectl delete crd builds.build.dev
+   $ kubectl delete crd buildstrategies.build.dev
+   $ kubectl delete crd clusterbuildstrategies.build.dev
+   ```


### PR DESCRIPTION
Announce the release of Shipwright Build v0.4.0. Includes instructions
on how to upgrade, migrate from v0.3.0, and uninstall v0.3.0 safely.