### PR TITLE
Switch build links to main branch

### DIFF
--- a/content/en/blog/posts/2020-11-30-intro-shipwright-pt2.md
+++ b/content/en/blog/posts/2020-11-30-intro-shipwright-pt2.md
@@ -137,7 +137,7 @@ spec:
 ```
 
 Builds can be extended to push to private registries, use a different Dockerfile, and more. Read the
-[docs](https://github.com/shipwright-io/build/blob/master/docs/build.md) for a deeper dive on what
+[docs](https://github.com/shipwright-io/build/blob/main/docs/build.md) for a deeper dive on what
 is possible.
 
 ### BuildRun

--- a/content/en/docs/api/buildstrategies.md
+++ b/content/en/docs/api/buildstrategies.md
@@ -32,7 +32,7 @@ There are two types of strategy API: the `ClusterBuildStrategy` (`clusterbuildst
 
 ## Available ClusterBuildStrategies
 
-Well-known strategies can be boostrapped from [GitHub](https://github.com/shipwright-io/build/tree/master/samples/buildstrategy). The current supported Cluster BuildStrategy are:
+Well-known strategies can be boostrapped from [GitHub](https://github.com/shipwright-io/build/tree/main/samples/buildstrategy). The current supported Cluster BuildStrategy are:
 
 - [buildah](../samples/buildstrategy/buildah/buildstrategy_buildah_cr.yaml)
 - [buildpacks-v3-heroku](../samples/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml)

--- a/content/en/docs/configuration.md
+++ b/content/en/docs/configuration.md
@@ -3,7 +3,7 @@ title: "Configuration"
 draft: false
 ---
 
-The controller is installed into Kubernetes with reasonable defaults. However, there are some settings that can be overridden using environment variables in [`500-controller.yaml`](https://github.com/shipwright-io/build/blob/master/deploy/500-controller.yaml).
+The controller is installed into Kubernetes with reasonable defaults. However, there are some settings that can be overridden using environment variables in [`500-controller.yaml`](https://github.com/shipwright-io/build/blob/main/deploy/500-controller.yaml).
 
 The following environment variables are available:
 

--- a/content/en/docs/metrics.md
+++ b/content/en/docs/metrics.md
@@ -38,7 +38,7 @@ export PROMETHEUS_BR_COMP_DUR_BUCKETS=30,60,90,120,180,240,300,360,420,480
 make local
 ```
 
-When you deploy the build controller in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [`500-controller.yaml`](https://github.com/shipwright-io/build/blob/master/deploy/500-controller.yaml).  
+When you deploy the build controller in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [`500-controller.yaml`](https://github.com/shipwright-io/build/blob/main/deploy/500-controller.yaml).  
 Add an additional entry:
 
 ```yaml
@@ -72,7 +72,7 @@ export PROMETHEUS_ENABLED_LABELS=buildstrategy,namespace,build
 make local
 ```
 
-When you deploy the build controller in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [`500-controller.yaml`](https://github.com/shipwright-io/build/blob/master/deploy/500-controller.yaml).  
+When you deploy the build controller in a Kubernetes cluster, you need to extend the `spec.containers[0].spec.env` section of the sample deployment file, [`500-controller.yaml`](https://github.com/shipwright-io/build/blob/main/deploy/500-controller.yaml).  
 Add an additional entry:
 
 ```yaml


### PR DESCRIPTION
shipwright-io/build will be switching its default branch from "master"
to "main". This renames the file links that point to branches in GitHub.

GitHub's branch renaming feature will establish a redirect for all links
that point to the "master" branch. This change ensures that we will not
rely on the redirect in the long run.