### PR TITLE
Fix doc for source branch

### DIFF
--- a/content/en/docs/api/build.md
+++ b/content/en/docs/api/build.md
@@ -139,7 +139,7 @@ metadata:
 spec:
   source:
     url: https://github.com/shipwright-io/sample-go
-    contextDir: docker-build
+    revision: docker-build
 ```
 
 ### Defining the Strategy

--- a/content/en/docs/api/build.md
+++ b/content/en/docs/api/build.md
@@ -139,7 +139,7 @@ metadata:
 spec:
   source:
     url: https://github.com/shipwright-io/sample-go
-    revision: docker-build
+    revision: v0.1.0
 ```
 
 ### Defining the Strategy


### PR DESCRIPTION
To reference a source branch you must use 'revision' and not 'contextDir'.