### PR TITLE
Fix git clone instructions on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use this repository, you need the following installed locally:
 Once installed, clone the repository and navigate to the directory:
 
 ```bash
-$ git clone https://github.com/shipwright-io/website.git
+$ git clone --recurse-submodules --depth 1 https://github.com/shipwright-io/website.git
 $ cd website
 ```
 


### PR DESCRIPTION
Add the  `--recurse-submodules --depth 1` arguments to the git clone
instructions in the README. This is needed to clone the docsy theme and
its dependencies.

See https://github.com/google/docsy-example

Fixes #44 