### PR TITLE
content: Fix broken link to build controller deployment YAML manifest

### DIFF
--- a/content/en/docs/configuration.md
+++ b/content/en/docs/configuration.md
@@ -3,7 +3,7 @@ title: "Configuration"
 draft: false
 ---
 
-The controller is installed into Kubernetes with reasonable defaults. However, there are some settings that can be overridden using environment variables in [`controller.yaml`](../deploy/500-controller.yaml).
+The controller is installed into Kubernetes with reasonable defaults. However, there are some settings that can be overridden using environment variables in [`controller.yaml`](https://github.com/shipwright-io/build/blob/v0.5.1/deploy/500-controller.yaml).
 
 The following environment variables are available:
 


### PR DESCRIPTION
Update the configuration.md documentation and fix the broken link to the
build controller deployment YAML manifest.