### PR TITLE
Create $HOME/bin directory before moving the hugo binary

### DIFF
--- a/hack/install-hugo.sh
+++ b/hack/install-hugo.sh
@@ -10,6 +10,7 @@ mkdir -p ${tmpDir}
 pushd ${tmpDir}
 wget "https://github.com/gohugoio/hugo/releases/download/v${hugoVersion}/hugo_extended_${hugoVersion}_${hugoOS}-64bit.tar.gz"
 tar -xzvf "hugo_extended_${hugoVersion}_${hugoOS}-64bit.tar.gz"
+mkdir -p ${installDir}
 mv hugo ${installDir}
 popd
 rm -rf ${tmpDir}


### PR DESCRIPTION
The script was placing the Hugo binary as a file named bin in the `$HOME` directory if the bin directory does not exist.