### PR TITLE
Fixes a broken link and missleading blog title

### DIFF
--- a/content/en/blog/posts/2021-10-26-build-release-v0.6.0.md
+++ b/content/en/blog/posts/2021-10-26-build-release-v0.6.0.md
@@ -1,5 +1,5 @@
 ---
-title: "Latest Shipwright release comes with better parameterization of builds, a CLI, and more"
+title: "Shipwright v0.6.0 Is Here"
 date: 2021-10-26T10:30:00-04:00
 draft: false
 author: "Sascha Schwarze ([@SaschaSchwarze0](https://github.com/SaschaSchwarze0))"

--- a/content/en/blog/posts/2021-12-20-build-release-v0.7.0.md
+++ b/content/en/blog/posts/2021-12-20-build-release-v0.7.0.md
@@ -7,7 +7,7 @@ author: "Sascha Schwarze ([@SaschaSchwarze0](https://github.com/SaschaSchwarze0)
 
 Ready for Christmas? We are, and our v0.7.0 release just made it!
 
-Is it a big thing just like our [previous v0.6.0 release](2021-10-26-build-release-v0.6.0.md)? No, but we have still done a couple of nice things:
+Is it a big thing just like our [previous v0.6.0 release](/blog/2021/10/26/shipwright-v0.6.0-is-here/)? No, but we have still done a couple of nice things:
 
 ## What's New
 


### PR DESCRIPTION
- Latest blog entry comes with a broken link, this fix it.
- A previous blog by the title "Latest Shipwright release" feels confusing, as is not longer the latest release. I added a more common name as the title, in order to match recent blog post names.