### PR TITLE
Add asciidoctor to Hugo's security configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ To use this repository, you need the following installed locally:
 
 * npm - this can be obtained by installing [Node.js](https://nodejs.org/en/download/) on your system
 * [Hugo](https://gohugo.io/getting-started/installing/) - be sure to install the **extended version**.
+* [Ruby](https://www.ruby-lang.org/en/)
 
 Once installed, clone the repository and navigate to the directory:
 
@@ -21,6 +22,8 @@ Once installed, clone the repository and navigate to the directory:
 $ git clone --recurse-submodules --depth 1 https://github.com/shipwright-io/website.git
 $ cd website
 ```
+
+Then install any additional dependencies by running `make install`
 
 ### Running the website locally
 

--- a/config.toml
+++ b/config.toml
@@ -175,3 +175,14 @@ enable = false
     url = "https://lists.shipwright.io/admin/lists/shipwright-dev.lists.shipwright.io/"
     icon = "fa fa-envelope"
     desc = "Discuss development issues around the project"
+
+[security]
+  enableInlineShortcodes = false
+  [security.exec]
+    allow = ['^dart-sass-embedded$', '^go$', '^npx$', '^postcss$', '^asciidoctor$']
+    osEnv = ['(?i)^(PATH|PATHEXT|APPDATA|TMP|TEMP|TERM)$']
+  [security.funcs]
+    getenv = ['^HUGO_']
+  [security.http]
+    methods = ['(?i)GET|POST']
+    urls = ['.*']


### PR DESCRIPTION
- Set up Hugo's security to allow asciidoctor to execute. See
  https://gohugo.io/about/security-model/
- Update README with added Ruby dependency. `asciidoctor` is installed
  with a Ruby gem.