### PR TITLE
Blog Post - Bringing Shipwright to Beta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,42 @@
-.PHONY: all build install netlify
-
+.PHONY: all
 all: build
 
-build:
-	rm -rf public/*
+.PHONY: build
+build: clean ## build the site
 	hugo -t docsy --minify
 
-serve:
-	hugo -t docsy server
+.PHONY: build-preview
+build-preview: clean ## build a preview, with future-dated content allowed.
+	hugo -t docsy -F --minify
 
-install:
+.PHONY: clean
+clean: ## clean the build assets
+	rm -rf public/*
+
+.PHONY: install
+install: ## install dependencies
 	bundle
 	npm install
 
-netlify:
+.PHONY: netlify
+netlify: submodule-init ## build the site for Netlify
 	git submodule update --init --recursive --depth 1
 	$(MAKE) install
 	$(MAKE) build
+
+.PHONY: netlify-preview
+netlify-preview: submodule-init ## build a preview of the site for Netlify
+	$(MAKE) install
+	$(MAKE) build-preview
+
+.PHONY: serve
+serve: ## serve the content locally for testing
+	hugo -t docsy server
+
+.PHONY: serve-preview
+serve-preview: ## serve the preview content locally for testing
+	hugo -t docsy server -F
+
+.PHONY: submodule-init
+submodule-init:
+	git submodule update --init --recursive --depth 1

--- a/content/en/blog/posts/2022-10-25-shipwright-beta.md
+++ b/content/en/blog/posts/2022-10-25-shipwright-beta.md
@@ -1,0 +1,91 @@
+---
+title: "Bringing Shipwright to Beta - and Beyond!"
+date: 2022-10-25T17:00:00-04:00
+draft: false
+---
+
+Recently, the Shipwright community came together to define a beta API for the
+[Build project](https://github.com/shipwright-io/build) with stronger support
+guarantees.
+We have come a long way since our launch two years ago, as "a framework for
+building container images on Kubernetes."
+During the workshop, the community found itself coming back to a fundamental
+question, "What is Shipwright?"
+And more importantly, "What do we want Shipwright to be?"
+
+## What Should Shipwright Become?
+
+We concluded that Shipwright is and should remain a framework for building
+container images.
+Shipwright will continue to make it simple to build a container image from
+source, using tools that are actively maintained by a community of experts.
+Our separation of [build strategy]({{% ref "/docs/build/buildstrategies" %}})
+from build definition and execution will remain a cornerstone of the Shipwright
+framework.
+
+However, we realized that building the image is just the starting point to
+delivering software on the cloud.
+Software supply chain security is a topmost concern of teams large and small.
+Artifacts like image scans, signatures,
+[software bill of materials](https://www.cisa.gov/sbom), and
+[provenance](https://in-toto.io/in-toto/) are needed to build modern software
+for the cloud.
+Shipwright can, and should, rise up to meet these demands.
+
+We also decided that Shipwright will continue to run on on cloud-native
+infrastructure, powered by [Kubernetes](https://kubernetes.io) and
+[Tekton](https://tekton.dev).
+We can go further, though, and plug Shipwright into the vast cloud-native
+ecosystem, through integrations with [cdEvents](https://cdevents.dev),
+[ArgoCD](https://argo-cd.readthedocs.io/en/stable/), and more.
+Shipwright is just getting started in this effort through the
+[Triggers](https://github.com/shipwright-io/triggers) and
+[Image](https://github.com/shipwright-io/image) sub-projects.
+
+## Core Values
+
+Over the past two years, the Shipwright community has coalesced around three
+core values: simplicity, flexibility, and security. 
+
+Simplicity means that we provide an experience that is intuitive and
+consistent.
+It also means that we shouldn’t be afraid to take an opinionated stance on
+common tasks, or features that we want to add to the project.
+We discovered in the Beta API workshop areas where our APIs were not consistent
+or intuitive, and we identified changes to fix these problem areas.
+These include single sources for builds and maintaining our opinionated steps
+to obtain source code.
+
+Flexibility means that we provide space for teams to bend Shipwright to fit
+their needs.
+This started with the build strategy model itself, which we are keeping at the
+core of the API.
+We continued with the Parameters API, which provides avenues for customization
+between build strategies and build executions.
+We also took steps in our beta workshop to ensure our API is tool agnostic,
+such that we can help grow the ecosystem of build tools.
+This meant that some fields that were only used by specific build tools were
+dropped.
+
+Lastly, Shipwright aims to meet the security needs for cloud-native
+applications.
+Security for Shipwright starts with the transparent pod security contexts built
+into the build strategy API.
+This encourages the continued evolution of tooling away from privileged and
+“root” containers, both of which are potential security risks.
+As a community, we have started experimenting with tools like
+[Trivy](https://github.com/aquasecurity/trivy) to make the security of
+Shipwright-built images more transparent.
+We hope to continue these efforts with emerging software security tools in the
+future.
+
+## Bringing Shipwright to Beta
+
+Starting in version 0.12, Shipwright will introduce the beta [Build API]({{% ref "/docs/build/build" %}})
+and begin phasing out the current alpha API.
+We encourage current and future users to provide feedback as we roll this new
+API out.
+You can provide feedback by filing an issue on [GitHub](https://github.com/shipwright-io/build/issues),
+sending an email to our [mailing list](mailto:shipwright-dev@lists.shipwright.io),
+or posting a message to the `#shipwright` channel on [Kubernetes Slack](https://kubernetes.slack.com/archives/C019ZRGUEJC).
+We look forward to hearing from you!

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,3 +4,6 @@ command="make netlify"
 
 [build.environment]
 HUGO_VERSION="0.99.1"
+
+[context.deploy-preview]
+command="make netlify-preview"


### PR DESCRIPTION
This blog post serves as an announcement of the forthcoming beta API.
The content is similar to the lightning talk Adam Kaplan will be giving
at CD Summit 2022 (co-located with KubeCon NA 2022).

This PR also includes support for future-dated content in our deploy previews.
We can use this to stage content before a broader announcement.
