### PR TITLE
Break out the CRDs for clarity

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -46,8 +46,8 @@ Shipwright's Build API consists of four core
 (CRDs):
 
 1. [`Build`](/docs/api/build/) - defines what to build, and where the application should be delivered.
-1. [`BuildStrategy` and `ClusterBuildStrategy`](/docs/api/buildstrategies/) - defines how to build an application for an image
-   building tool.
+1. [`BuildStrategy`](/docs/api/buildstrategies/) - defines how to build an application for an image building tool.
+1. [`ClusterBuildStrategy`](/docs/api/buildstrategies/) - as above, at the cluster level.
 1. [`BuildRun`](/docs/api/buildrun/) - invokes the build.
    You create a `BuildRun` to tell Shipwright to start building your application.
 


### PR DESCRIPTION
# Changes

Simple change to break out the CRDs. If nothing else, it provides clarity when 4 CRDs are mentioned, but the list looks like it contains only 3 (I realize they are there, but on first glance...)

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!--
```release-note
NONE
```
-->
