### PR TITLE
updated the prerequisites in the getting started section

### DIFF
--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -10,11 +10,11 @@ with our operator.
 
 ## Prerequsites
 
-- Shipwright runs on top of [Kubernetes](https://kubernetes.io/), and requires a cluster running version 1.21 or higher.
-- We also require a Tekton installation (v0.41.+). To install the newest supported version, run:
+- [Kubernetes](https://kubernetes.io/) 1.21 or later.
+- [Tekton pipelines](https://tekton.dev/docs/installation/) v0.41 or later. 
 
   ```bash
-  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.44.0/release.yaml
+  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
   ```
 
 ## Installing Shipwright Builds with the Operator
@@ -57,7 +57,7 @@ We also publish a Kubernetes manifest that installs Shipwright directly into the
 Applying this manifest requires cluster administrator permissions:
 
 ```bash
-$ kubectl apply -f https://github.com/shipwright-io/build/releases/download/v0.11.0/release.yaml
+$ kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/release.yaml
 ```
 
 ## Installing Sample Build Strategies
@@ -66,5 +66,5 @@ The Shipwright community maintains a curated set of build strategies for popular
 These can be optionally installed after Shipwright Builds has been deployed:
 
 ```bash
-$ kubectl apply -f https://github.com/shipwright-io/build/releases/download/v0.11.0/sample-strategies.yaml
+$ kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/sample-strategies.yaml
 ```

--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -10,7 +10,12 @@ with our operator.
 
 ## Prerequsites
 
-Shipwright runs on top of [Kubernetes](https://kubernetes.io/), and requires a cluster running version 1.21 or higher.
+- Shipwright runs on top of [Kubernetes](https://kubernetes.io/), and requires a cluster running version 1.21 or higher.
+- We also require a Tekton installation (v0.41.+). To install the newest supported version, run:
+
+  ```bash
+  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.44.0/release.yaml
+  ```
 
 ## Installing Shipwright Builds with the Operator
 
@@ -52,7 +57,7 @@ We also publish a Kubernetes manifest that installs Shipwright directly into the
 Applying this manifest requires cluster administrator permissions:
 
 ```bash
-$ kubectl apply -f https://github.com/shipwright-io/build/releases/download/v0.10.0/release.yaml
+$ kubectl apply -f https://github.com/shipwright-io/build/releases/download/v0.11.0/release.yaml
 ```
 
 ## Installing Sample Build Strategies
@@ -61,5 +66,5 @@ The Shipwright community maintains a curated set of build strategies for popular
 These can be optionally installed after Shipwright Builds has been deployed:
 
 ```bash
-$ kubectl apply -f https://github.com/shipwright-io/build/releases/download/v0.10.0/sample-strategies.yaml
+$ kubectl apply -f https://github.com/shipwright-io/build/releases/download/v0.11.0/sample-strategies.yaml
 ```


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
Solves #93 Updated the prerequisites in the getting started section. Changed the installation URLs to use v0.11.0 and added tekton as a prerequisite.

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->

# Submitter Checklist
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```

