### PR TITLE
Remove deprecated terms from config.toml

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["term", "taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true
@@ -52,12 +52,13 @@ anchor = "smart"
 # Language configuration
 
 [languages]
-[languages.en]
-title = "Shipwright"
-description = "A framework for building container images on Kubernetes"
-languageName ="English"
-# Weight used for sorting.
-weight = 1
+  [languages.en]
+    title = "Shipwright"
+    languageName ="English"
+    # Weight used for sorting.
+    weight = 1
+    [languages.en.params]
+      description = "A framework for building container images on Kubernetes"
 
 [markup]
   [markup.goldmark]


### PR DESCRIPTION
# Changes
Removes deprecated variables from config.toml
- https://github.com/gohugoio/hugo/releases/tag/v0.73.0
- https://gohugo.io/content-management/multilingual/#changes-in-hugo-01120

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
