### PR TITLE
Syncs content/en with shipwright.io/build/docs

### DIFF
--- a/content/en/docs/build/build.md
+++ b/content/en/docs/build/build.md
@@ -19,21 +19,22 @@ SPDX-License-Identifier: Apache-2.0
   - [Defining the Output](#defining-the-output)
   - [Defining Retention Parameters](#defining-retention-parameters)
   - [Defining Volumes](#defining-volumes)
-- [BuildRun deletion](#BuildRun-deletion)
+  - [Defining Triggers](#defining-triggers)
+- [BuildRun deletion](#buildrun-deletion)
 
 ## Overview
 
 A `Build` resource allows the user to define:
 
 - source
-- sources
+- trigger
 - strategy
-- params
-- builder
-- dockerfile
+- paramValues
 - output
+- timeout
 - env
 - retention
+- volumes
 
 A `Build` is available within a namespace.
 
@@ -45,54 +46,75 @@ The controller watches for:
 
 When the controller reconciles it:
 
-- Validates if the referenced `StrategyRef` exists.
-- Validates if the specified `params` exist on the referenced strategy parameters. It also validates if the `params` names collide with the Shipwright reserved names.
+- Validates if the referenced `Strategy` exists.
+- Validates if the specified `paramValues` exist on the referenced strategy parameters. It also validates if the `paramValues` names collide with the Shipwright reserved names.
 - Validates if the container `registry` output secret exists.
-- Validates if the referenced `spec.source.url` endpoint exists.
+- Validates if the referenced `spec.source.git.url` endpoint exists.
 
 ## Build Validations
 
-To prevent users from triggering `BuildRuns` (_execution of a Build_) that will eventually fail because of wrong or missing dependencies or configuration settings, the Build controller will validate them in advance. If all validations are successful, users can expect a `Succeeded` `status.reason`. However, if any validations fail, users can rely on the `status.reason` and `status.message` fields to understand the root cause.
+**Note**: reported validations in build status are deprecated, and will be removed in a future release.
 
-| Status.Reason | Description |
-| --- | --- |
-| BuildStrategyNotFound   | The referenced namespace-scope strategy doesn't exist. |
-| ClusterBuildStrategyNotFound   | The referenced cluster-scope strategy doesn't exist. |
-| SetOwnerReferenceFailed   | Setting ownerreferences between a Build and a BuildRun failed. This status is triggered when using the `build.shipwright.io/build-run-deletion` annotation in a Build. |
-| SpecSourceSecretRefNotFound | The secret used to authenticate to git doesn't exist. |
-| SpecOutputSecretRefNotFound | The secret used to authenticate to the container registry doesn't exist. |
-| SpecBuilderSecretRefNotFound | The secret used to authenticate the container registry doesn't exist.|
-| MultipleSecretRefNotFound | More than one secret is missing. At the moment, only three paths on a Build can specify a secret. |
-| RestrictedParametersInUse | One or many defined `params` are colliding with Shipwright reserved parameters. See [Defining Params](#defining-params) for more information. |
-| UndefinedParameter | One or many defined `params` are not defined in the referenced strategy. Please ensure that the strategy defines them under its `spec.parameters` list. |
-| RemoteRepositoryUnreachable | The defined `spec.source.url` was not found. This validation only takes place for HTTP/HTTPS protocols. |
-| BuildNameInvalid | The defined `Build` name (`metadata.name`) is invalid. The `Build` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
-| SpecEnvNameCanNotBeBlank | Indicates that the name for a user-provided environment variable is blank. |
-| SpecEnvValueCanNotBeBlank | Indicates that the value for a user-provided environment variable is blank. |
+To prevent users from triggering `BuildRun`s (_execution of a Build_) that will eventually fail because of wrong or missing dependencies or configuration settings, the Build controller will validate them in advance. If all validations are successful, users can expect a `Succeeded` `status.reason`. However, if any validations fail, users can rely on the `status.reason` and `status.message` fields to understand the root cause.
+
+| Status.Reason                                   | Description                                                                                                                                                                                                  |
+|-------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| BuildStrategyNotFound                           | The referenced namespace-scope strategy doesn't exist.                                                                                                                                                       |
+| ClusterBuildStrategyNotFound                    | The referenced cluster-scope strategy doesn't exist.                                                                                                                                                         |
+| SetOwnerReferenceFailed                         | Setting ownerreferences between a Build and a BuildRun failed. This status is triggered when you set the `spec.retention.atBuildDeletion` to true in a Build.                                                |
+| SpecSourceSecretRefNotFound                     | The secret used to authenticate to git doesn't exist.                                                                                                                                                        |
+| SpecOutputSecretRefNotFound                     | The secret used to authenticate to the container registry doesn't exist.                                                                                                                                     |
+| SpecBuilderSecretRefNotFound                    | The secret used to authenticate the container registry doesn't exist.                                                                                                                                        |
+| MultipleSecretRefNotFound                       | More than one secret is missing. At the moment, only three paths on a Build can specify a secret.                                                                                                            |
+| RestrictedParametersInUse                       | One or many defined `paramValues` are colliding with Shipwright reserved parameters. See [Defining Params](#defining-paramvalues) for more information.                                                      |
+| UndefinedParameter                              | One or many defined `paramValues` are not defined in the referenced strategy. Please ensure that the strategy defines them under its `spec.parameters` list.                                                 |
+| RemoteRepositoryUnreachable                     | The defined `spec.source.git.url` was not found. This validation only takes place for HTTP/HTTPS protocols.                                                                                                  |
+| BuildNameInvalid                                | The defined `Build` name (`metadata.name`) is invalid. The `Build` name should be a [valid label value](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set). |
+| SpecEnvNameCanNotBeBlank                        | The name for a user-provided environment variable is blank.                                                                                                                                                  |
+| SpecEnvValueCanNotBeBlank                       | The value for a user-provided environment variable is blank.                                                                                                                                                 |
+| SpecEnvOnlyOneOfValueOrValueFromMustBeSpecified | Both value and valueFrom were specified, which are mutually exclusive.                                                                                                                                       |
+| RuntimePathsCanNotBeEmpty                       | The `spec.runtime` feature is used but the paths were not specified.                                                                                                                                         |
+| WrongParameterValueType                         | A single value was provided for an array parameter, or vice-versa.                                                                                                                                           |
+| InconsistentParameterValues                     | Parameter values have more than one of _configMapValue_, _secretValue_, or _value_ set.                                                                                                                      |
+| EmptyArrayItemParameterValues                   | Array parameters contain an item where none of _configMapValue_, _secretValue_, or _value_ is set.                                                                                                           |
+| IncompleteConfigMapValueParameterValues         | A _configMapValue_ is specified where the name or the key is empty.                                                                                                                                          |
+| IncompleteSecretValueParameterValues            | A _secretValue_ is specified where the name or the key is empty.                                                                                                                                             |
+| VolumeDoesNotExist                              | Volume referenced by the Build does not exist, therefore Build cannot be run.                                                                                                                                |
+| VolumeNotOverridable                            | Volume defined by build is not set as overridable in the strategy.                                                                                                                                           |
+| UndefinedVolume                                 | Volume defined by build is not found in the strategy.                                                                                                                                                        |
+| TriggerNameCanNotBeBlank                        | Trigger condition does not have a name.                                                                                                                                                                      |
+| TriggerInvalidType                              | Trigger type is invalid.                                                                                                                                                                                     |
+| TriggerInvalidGitHubWebHook                     | Trigger type GitHub is invalid.                                                                                                                                                                              |
+| TriggerInvalidImage                             | Trigger type Image is invalid.                                                                                                                                                                               |
+| TriggerInvalidPipeline                          | Trigger type Pipeline is invalid.                                                                                                                                                                            |
+| OutputTimestampNotSupported                     | An unsupported output timestamp setting was used.                                                                                                                                                            |
+| OutputTimestampNotValid                         | The output timestamp value is not valid.                                                                                                                                                                     |
 
 ## Configuring a Build
 
 The `Build` definition supports the following fields:
 
 - Required:
-  - [`apiVersion`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the API version, for example `shipwright.io/v1alpha1`.
+  - [`apiVersion`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the API version, for example `shipwright.io/v1beta1`.
   - [`kind`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Specifies the Kind type, for example `Build`.
-  - [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Metadata that identify the CRD instance, for example the name of the `Build`.
-  - `spec.source` - Refers to the location of the source code, for example a Git repository or source bundle image.
-  - `spec.strategy` - Refers to the `BuildStrategy` to be used, see the [examples](../samples/buildstrategy)
-  - `spec.builder.image` - Refers to the image containing the build tools to build the source code. (_Use this path for Dockerless strategies, this is just required for `source-to-image` buildStrategy_)
+  - [`metadata`](https://kubernetes.io/docs/concepts/overview/working-with-objects/kubernetes-objects/#required-fields) - Metadata that identify the custom resource instance, especially the name of the `Build`, and in which [namespace](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/) you place it. **Note**: You should use your own namespace, and not put your builds into the shipwright-build namespace where Shipwright's system components run.
+  - `spec.source` - Refers to the location of the source code, for example a Git repository or OCI artifact image.
+  - `spec.strategy` - Refers to the `BuildStrategy` to be used, see the [examples](../samples/v1beta1/buildstrategy)
   - `spec.output`- Refers to the location where the generated image would be pushed.
-  - `spec.output.credentials.name`- Reference an existing secret to get access to the container registry.
+  - `spec.output.pushSecret`- Reference an existing secret to get access to the container registry.
 
 - Optional:
   - `spec.paramValues` - Refers to a name-value(s) list to specify values for `parameters` defined in the `BuildStrategy`.
-  - `spec.dockerfile` - Path to a Dockerfile to be used for building an image. (_Use this path for strategies that require a Dockerfile_)
-  - `spec.sources` - [Sources](#Sources) describes a slice of artifacts that will be imported into the project context before the actual build process starts.
   - `spec.timeout` - Defines a custom timeout. The value needs to be parsable by [ParseDuration](https://golang.org/pkg/time/#ParseDuration), for example, `5m`. The default is ten minutes. You can overwrite the value in the `BuildRun`.
-  - `metadata.annotations[build.shipwright.io/build-run-deletion]` - Defines if delete all related BuildRuns when deleting the Build. The default is `false`.
   - `spec.output.annotations` - Refers to a list of `key/value` that could be used to [annotate](https://github.com/opencontainers/image-spec/blob/main/annotations.md) the output image.
   - `spec.output.labels` - Refers to a list of `key/value` that could be used to label the output image.
+  - `spec.output.timestamp` - Instruct the build to change the output image creation timestamp to the specified value. When omitted, the respective build strategy tool defines the output image timestamp.
+    - Use string `Zero` to set the image timestamp to UNIX epoch timestamp zero.
+    - Use string `SourceTimestamp` to set the image timestamp to the source timestamp, i.e. the timestamp of the Git commit that was used.
+    - Use string `BuildTimestamp` to set the image timestamp to the timestamp of the build run.
+    - Use any valid UNIX epoch seconds number as a string to set this as the image timestamp.
   - `spec.env` - Specifies additional environment variables that should be passed to the build container. The available variables depend on the tool that is being used by the chosen build strategy.
+  - `spec.retention.atBuildDeletion` - Defines if all related BuildRuns needs to be deleted when deleting the Build. The default is false.
   - `spec.retention.ttlAfterFailed` - Specifies the duration for which a failed buildrun can exist.
   - `spec.retention.ttlAfterSucceeded` - Specifies the duration for which a successful buildrun can exist.
   - `spec.retention.failedLimit` - Specifies the number of failed buildrun that can exist.
@@ -100,21 +122,20 @@ The `Build` definition supports the following fields:
 
 ### Defining the Source
 
-A `Build` resource can specify a Git repository or bundle image source, together with other parameters like:
+A `Build` resource can specify a source type, such as a Git repository or an OCI artifact, together with other parameters like:
 
-- `source.url` - Specify the source location using a Git repository.
-- `source.bundleContainer.image` - Specify a source bundle container image to be used as the source.
-- `source.bundleContainer.prune` - Configure whether the source bundle image should be deleted after the source was obtained (defaults to `Never`, other option is `AfterPull` to delete the image after a successful image pull).
-- `source.credentials.name` - For private repositories or registries, the name references a secret in the namespace that contains the SSH private key or Docker access credentials, respectively.
-- `source.revision` - A specific revision to select from the source repository, this can be a commit, tag or branch name. If not defined, it will fallback to the Git repository default branch.
+- `source.type` - Specify the type of the data-source. Currently, the supported types are "Git", "OCIArtifact", and "Local".
+- `source.git.url` - Specify the source location using a Git repository.
+- `source.git.cloneSecret` - For private repositories or registries, the name references a secret in the namespace that contains the SSH private key or Docker access credentials, respectively.
+- `source.git.revision` - A specific revision to select from the source repository, this can be a commit, tag or branch name. If not defined, it will fallback to the Git repository default branch.
 - `source.contextDir` - For repositories where the source code is not located at the root folder, you can specify this path here.
 
 By default, the Build controller does not validate that the Git repository exists. If the validation is desired, users can explicitly define the `build.shipwright.io/verify.repository` annotation with `true`. For example:
 
-Example of a `Build` with the **build.shipwright.io/verify.repository** annotation to enable the `spec.source.url` validation.
+Example of a `Build` with the **build.shipwright.io/verify.repository** annotation to enable the `spec.source.git.url` validation.
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildah-golang-build
@@ -122,63 +143,72 @@ metadata:
     build.shipwright.io/verify.repository: "true"
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-go
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
     contextDir: docker-build
 ```
 
-_Note_: The Build controller only validates two scenarios. The first one is when the endpoint uses an `http/https` protocol. The second one is when an `ssh` protocol such as `git@` has been defined but a referenced secret, such as `source.credentials.name`, has not been provided.
+**Note**: The Build controller only validates two scenarios. The first one is when the endpoint uses an `http/https` protocol. The second one is when an `ssh` protocol such as `git@` has been defined but a referenced secret, such as `source.git.cloneSecret`, has not been provided.
 
 Example of a `Build` with a source with **credentials** defined by the user.
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildpack-nodejs-build
 spec:
   source:
-    url: https://github.com/sclorg/nodejs-ex
-    credentials:
-      name: source-repository-credentials
+    type: Git
+    git:
+      url: https://github.com/sclorg/nodejs-ex
+      cloneSecret: source-repository-credentials
 ```
 
 Example of a `Build` with a source that specifies a specific subfolder on the repository.
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildah-custom-context-dockerfile
 spec:
   source:
-    url: https://github.com/SaschaSchwarze0/npm-simple
+    type: Git
+    git:
+      url: https://github.com/SaschaSchwarze0/npm-simple
     contextDir: renamed
 ```
 
-Example of a `Build` that specifies the tag `v.0.1.0` for the git repository:
+Example of a `Build` that specifies the tag `v0.1.0` for the git repository:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-go
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
+      revision: v0.1.0
     contextDir: docker-build
-    revision: v0.1.0
 ```
 
 Example of a `Build` that specifies environment variables:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-go
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
     contextDir: docker-build
   env:
     - name: EXAMPLE_VAR_1
@@ -187,17 +217,18 @@ spec:
       value: "example-value-2"
 ```
 
-Example of a `Build` that uses the Kubernetes Downward API to
-expose a `Pod` field as an environment variable:
+Example of a `Build` that uses the Kubernetes Downward API to expose a `Pod` field as an environment variable:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-go
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
     contextDir: docker-build
   env:
     - name: POD_NAME
@@ -206,17 +237,18 @@ spec:
           fieldPath: metadata.name
 ```
 
-Example of a `Build` that uses the Kubernetes Downward API to
-expose a `Container` field as an environment variable:
+Example of a `Build` that uses the Kubernetes Downward API to expose a `Container` field as an environment variable:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-go
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
     contextDir: docker-build
   env:
     - name: MEMORY_LIMIT
@@ -240,7 +272,7 @@ A `Build` resource can specify the `BuildStrategy` to use, these are:
 Defining the strategy is straightforward. You define the `name` and the `kind`. For example:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildpack-nodejs-build
@@ -267,10 +299,10 @@ In general, _paramValues_ are tightly bound to Strategy _parameters_. Please mak
 
 #### Example
 
-The [BuildKit sample `BuildStrategy`](../samples/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml) contains various parameters. Two of them are outlined here:
+The [BuildKit sample `BuildStrategy`](../samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml) contains various parameters. Two of them are outlined here:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: ClusterBuildStrategy
 metadata:
   name: buildkit
@@ -286,14 +318,14 @@ spec:
     type: string
     default: registry
   ...
-  buildSteps:
+  steps:
   ...
 ```
 
 The `cache` parameter is a simple string. You can provide it like this in your Build:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: a-build
@@ -326,7 +358,7 @@ data:
 You reference the ConfigMap as a parameter value like this:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: a-build
@@ -349,7 +381,7 @@ spec:
 The `build-args` parameter is defined as an array. In the BuildKit strategy, you use `build-args` to set the [`ARG` values in the Dockerfile](https://docs.docker.com/engine/reference/builder/#arg), specified as key-value pairs separated by an equals sign, for example, `NODE_VERSION=16`. Your Build then looks like this (the value for `cache` is retained to outline how multiple _paramValue_ can be set):
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: a-build
@@ -375,7 +407,7 @@ spec:
 Like simple values, you can also reference ConfigMaps and Secrets for every item in the array. Example:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: a-build
@@ -412,67 +444,77 @@ Here, we pass three items in the `build-args` array:
 2. The second item is just a hard-coded value.
 3. The third item references a Secret, the same as with ConfigMaps.
 
-**NOTE**: The logging output of BuildKit contains expanded `ARG`s in `RUN` commands. Also, such information ends up in the final container image if you use such args in the [final stage of your Dockerfile](https://docs.docker.com/develop/develop-images/multistage-build/). An alternative approach to pass secrets is using [secret mounts](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information). The BuildKit sample strategy supports them using the `secrets` parameter.
+**Note**: The logging output of BuildKit contains expanded `ARG`s in `RUN` commands. Also, such information ends up in the final container image if you use such args in the [final stage of your Dockerfile](https://docs.docker.com/develop/develop-images/multistage-build/). An alternative approach to pass secrets is using [secret mounts](https://docs.docker.com/develop/develop-images/build_enhancements/#new-docker-build-secret-information). The BuildKit sample strategy supports them using the `secrets` parameter.
 
 ### Defining the Builder or Dockerfile
 
-In the `Build` resource, you use the `spec.builder` or `spec.dockerfile` parameters to specify the image that contains the tools to build the final image. For example, the following Build definition specifies a `Dockerfile` image.
+In the `Build` resource, you use the parameters (`spec.paramValues`) to specify the image that contains the tools to build the final image. For example, the following Build definition specifies a `Dockerfile` image.
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: buildah-golang-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-go
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
     contextDir: docker-build
   strategy:
     name: buildah
     kind: ClusterBuildStrategy
-  dockerfile: Dockerfile
+  paramValues:
+  - name: dockerfile
+    value: Dockerfile
 ```
 
 Another example is when the user chooses the `builder` image for a specific language as part of the `source-to-image` buildStrategy:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-nodejs
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-nodejs
     contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy
-  builder:
-    image: docker.io/centos/nodejs-10-centos7
+  paramValues:
+  - name: builder-image
+    value: "docker.io/centos/nodejs-10-centos7"
 ```
 
 ### Defining the Output
 
-A `Build` resource can specify the output where it should push the image. For external private registries, it is recommended to specify a secret with the related data to access it. An option is available to specify the annotation and labels for the output image. The annotations and labels mentioned here are specific to the container image and do not relate to the `Build` annotations.
+A `Build` resource can specify the output where it should push the image. For external private registries, it is recommended to specify a secret with the related data to access it. An option is available to specify the annotation and labels for the output image. The annotations and labels mentioned here are specific to the container image and do not relate to the `Build` annotations. Analogous, the timestamp refers to the timestamp of the output image.
 
-**NOTE**: When you specify annotations or labels, the output image will get pushed twice. The first push comes from the build strategy. Then, a follow-on update changes the image configuration to add the annotations and labels. If you have automation based on push events in your container registry, be aware of this behavior.
+**Note**: When you specify annotations, labels, or timestamp, the output image **may** get pushed twice, depending on the respective strategy. For example, strategies that push the image to the registry as part of their build step will lead to an additional push of the image in case image processing like labels is configured. If you have automation based on push events in your container registry, be aware of this behavior.
 
 For example, the user specifies a public registry:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-nodejs
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-nodejs
     contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy
-  builder:
-    image: docker.io/centos/nodejs-10-centos7
+  paramValues:
+  - name: builder-image
+    value: "docker.io/centos/nodejs-10-centos7"
   output:
     image: image-registry.openshift-image-registry.svc:5000/build-examples/nodejs-ex
 ```
@@ -480,45 +522,48 @@ spec:
 Another example is when the user specifies a private registry:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-nodejs
+    git:
+      url: https://github.com/shipwright-io/sample-nodejs
     contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy
-  builder:
-    image: docker.io/centos/nodejs-10-centos7
+  paramValues:
+  - name: builder-image
+    value: "docker.io/centos/nodejs-10-centos7"
   output:
     image: us.icr.io/source-to-image-build/nodejs-ex
-    credentials:
-      name: icr-knbuild
+    pushSecret: icr-knbuild
 ```
 
 Example of user specifies image annotations and labels:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: s2i-nodejs-build
 spec:
   source:
-    url: https://github.com/shipwright-io/sample-nodejs
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-nodejs
     contextDir: source-build/
   strategy:
     name: source-to-image
     kind: ClusterBuildStrategy
-  builder:
-    image: docker.io/centos/nodejs-10-centos7
+  paramValues:
+  - name: builder-image
+    value: "docker.io/centos/nodejs-10-centos7"
   output:
     image: us.icr.io/source-to-image-build/nodejs-ex
-    credentials:
-      name: icr-knbuild
+    pushSecret: icr-knbuild
     annotations:
       "org.opencontainers.image.source": "https://github.com/org/repo"
       "org.opencontainers.image.url": "https://my-company.com/images"
@@ -527,16 +572,38 @@ spec:
       "description": "This is my cool image"
 ```
 
+Example of user specified image timestamp set to `SourceTimestamp` to set the output timestamp to match the timestamp of the Git commit used for the build:
+
+```yaml
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: sample-go-build
+spec:
+  source:
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
+    contextDir: source-build
+  strategy:
+    name: buildkit
+    kind: ClusterBuildStrategy
+  output:
+    image: some.registry.com/namespace/image:tag
+    pushSecret: credentials
+    timestamp: SourceTimestamp
+```
+
 Annotations added to the output image can be verified by running the command:
 
 ```sh
-  docker manifest inspect us.icr.io/source-to-image-build/nodejs-ex | jq ".annotations"
+docker manifest inspect us.icr.io/source-to-image-build/nodejs-ex | jq ".annotations"
 ```
 
 You can verify which labels were added to the output image that is available on the host machine by running the command:
 
 ```sh
-  docker inspect us.icr.io/source-to-image-build/nodejs-ex | jq ".[].Config.Labels"
+docker inspect us.icr.io/source-to-image-build/nodejs-ex | jq ".[].Config.Labels"
 ```
 
 ### Defining Retention Parameters
@@ -545,6 +612,7 @@ A `Build` resource can specify how long a completed BuildRun can exist and the n
 
 As part of the retention parameters, we have the following fields:
 
+- `retention.atBuildDeletion` - Defines if all related BuildRuns needs to be deleted when deleting the Build. The default is false.
 - `retention.succeededLimit` - Defines number of succeeded BuildRuns for a Build that can exist.
 - `retention.failedLimit` - Defines number of failed BuildRuns for a Build that can exist.
 - `retention.ttlAfterFailed` - Specifies the duration for which a failed buildrun can exist.
@@ -553,13 +621,15 @@ As part of the retention parameters, we have the following fields:
 An example of a user using both TTL and Limit retention fields. In case of such a configuration, BuildRun will get deleted once the first criteria is met.
 
 ```yaml
-  apiVersion: shipwright.io/v1alpha1
+  apiVersion: shipwright.io/v1beta1
   kind: Build
   metadata:
     name: build-retention-ttl
   spec:
     source:
-      url: "https://github.com/shipwright-io/sample-go"
+      type: Git
+      git:
+        url: "https://github.com/shipwright-io/sample-go"
       contextDir: docker-build
     strategy:
       kind: ClusterBuildStrategy
@@ -572,30 +642,34 @@ An example of a user using both TTL and Limit retention fields. In case of such 
       succeededLimit: 20
 ```
 
-**NOTE**: When changes are made to `retention.failedLimit` and `retention.succeededLimit` values, they come into effect as soon as the build is applied, thereby enforcing the new limits. On the other hand, changing the `retention.ttlAfterFailed` and `retention.ttlAfterSucceeded` values will only affect new buildruns. Old buildruns will adhere to the old TTL retention values. In case TTL values are defined in buildrun specifications as well as build specifications, priority will be given to the values defined in the buildrun specifications.
+**Note**: When changes are made to `retention.failedLimit` and `retention.succeededLimit` values, they come into effect as soon as the build is applied, thereby enforcing the new limits. On the other hand, changing the `retention.ttlAfterFailed` and `retention.ttlAfterSucceeded` values will only affect new buildruns. Old buildruns will adhere to the old TTL retention values. In case TTL values are defined in buildrun specifications as well as build specifications, priority will be given to the values defined in the buildrun specifications.
 
 ### Defining Volumes
 
 `Builds` can declare `volumes`. They must override `volumes` defined by the according `BuildStrategy`. If a `volume`
 is not `overridable` then the `BuildRun` will eventually fail.
 
-`Volumes` follow the declaration of [Pod Volumes](https://kubernetes.io/docs/concepts/storage/volumes/), so 
+`Volumes` follow the declaration of [Pod Volumes](https://kubernetes.io/docs/concepts/storage/volumes/), so
 all the usual `volumeSource` types are supported.
 
 Here is an example of `Build` object that overrides `volumes`:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: build-name
 spec:
   source:
-    url: https://github.com/example/url
+    type: Git
+    git:
+      url: https://github.com/example/url
   strategy:
     name: buildah
     kind: ClusterBuildStrategy
-  dockerfile: Dockerfile
+  paramValues:
+  - name: dockerfile
+    value: Dockerfile
   output:
     image: registry/namespace/image:latest
   volumes:
@@ -604,41 +678,122 @@ spec:
         name: test-config
 ```
 
-### Sources
+### Defining Triggers
 
-Sources represent remote artifacts, as in external entities added to the build context before the actual Build starts. Therefore, you may employ `.spec.sources` to download artifacts from external repositories.
+Using the triggers, you can submit `BuildRun` instances when certain events happen. The idea is to be able to trigger Shipwright builds in an event driven fashion, for that purpose you can watch certain types of events.
+
+**Note**: triggers rely on the [Shipwright Triggers](https://github.com/shipwright-io/triggers) project to be deployed and configured in the same Kubernetes cluster where you run Shipwright Build. If it is not set up, the triggers defined in a Build are ignored.
+
+The types of events under watch are defined on the `.spec.trigger` attribute, please consider the following example:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+apiVersion: shipwright.io/v1beta1
 kind: Build
-metadata:
-  name: nodejs-ex
 spec:
-  sources:
-    - name: project-logo
-      url: https://gist.github.com/project/image.png
+  source:
+    type: Git
+    git:
+      url: https://github.com/shipwright-io/sample-go
+      cloneSecret: webhook-secret
+    contextDir: docker-build
+  trigger:
+    when: []
 ```
 
-Under `.spec.sources` are the following attributes:
+Certain types of events will use attributes defined on `.spec.source` to complete the information needed in order to dispatch events.
 
-- `.name`: represents the name of the resource, required attribute.
-- `.url`: universal resource location (URL), required attribute.
+#### GitHub
 
-When downloading artifacts, the process is executed in the same directory where the application source-code is located, by default `/workspace/source`.
+The GitHub type is meant to react upon events coming from GitHub WebHook interface, the events are compared against the existing `Build` resources, and therefore it can identify the `Build` objects based on `.spec.source.git.url` combined with the attributes on `.spec.trigger.when[].github`.
 
-Additionally, we plan to keep evolving `.spec.sources` by adding more types of remote data declaration. This API field works as an extension point to support external and internal resource locations.
+To identify a given `Build` object, the first criteria is the repository URL, and then the branch name listed on the GitHub event payload must also match. Following the criteria:
 
-At this initial stage, authentication is not supported; therefore, you can only download from sources without this mechanism in place.
+- First, the branch name is checked against the `.spec.trigger.when[].github.branches` entries
+- If the `.spec.trigger.when[].github.branches` is empty, the branch name is compared against `.spec.source.git.revision`
+- If `spec.source.git.revision` is empty, the default revision name is used ("main")
 
-## BuildRun deletion
-
-A `Build` can automatically delete a related `BuildRun`. To enable this feature set the  `build.shipwright.io/build-run-deletion` annotation to `true` in the `Build` instance. This annotation is not present in a `Build` definition by default. See an example of how to define this annotation:
+The following snippet shows a configuration matching `Push` and `PullRequest` events on the `main` branch, for example:
 
 ```yaml
-apiVersion: shipwright.io/v1alpha1
+# [...]
+spec:
+  source:
+    git:
+      url: https://github.com/shipwright-io/sample-go
+  trigger:
+    when:
+      - name: push and pull-request on the main branch
+        type: GitHub
+        github:
+          events:
+            - Push
+            - PullRequest
+          branches:
+            - main
+```
+
+#### Image
+
+In order to watch over images, in combination with the [Image](https://github.com/shipwright-io/image) controller, you can trigger new builds when those container image names change.
+
+For instance, lets imagine the image named `ghcr.io/some/base-image` is used as input for the Build process and every time it changes we would like to trigger a new build. Please consider the following snippet:
+
+```yaml
+# [...]
+spec:
+  trigger:
+    when:
+      - name: watching for the base-image changes
+        type: Image
+        image:
+          names:
+            - ghcr.io/some/base-image:latest
+```
+
+#### Tekton Pipeline
+
+Shipwright can also be used in combination with [Tekton Pipeline](https://github.com/tektoncd/pipeline), you can configure the Build to watch for `Pipeline` resources in Kubernetes reacting when the object reaches the desired status (`.objectRef.status`), and is identified either by its name (`.objectRef.name`) or a label selector (`.objectRef.selector`). The example below uses the label selector approach:
+
+```yaml
+# [...]
+spec:
+  trigger:
+    when:
+      - name: watching over for the Tekton Pipeline
+        type: Pipeline
+        objectRef:
+          status:
+            - Succeeded
+          selector:
+            label: value
+```
+
+While the next snippet uses the object name for identification:
+
+```yaml
+# [...]
+spec:
+  trigger:
+    when:
+      - name: watching over for the Tekton Pipeline
+        type: Pipeline
+        objectRef:
+          status:
+            - Succeeded
+          name: tekton-pipeline-name
+```
+
+## BuildRun Deletion
+
+A `Build` can automatically delete a related `BuildRun`. To enable this feature set the `spec.retention.atBuildDeletion` to `true` in the `Build` instance. The default value is set to `false`. See an example of how to define this field:
+
+```yaml
+apiVersion: shipwright.io/v1beta1
 kind: Build
 metadata:
   name: kaniko-golang-build
-  annotations:
-    build.shipwright.io/build-run-deletion: "true"
+spec:
+  retention:
+    atBuildDeletion: true
+  # [...]
 ```

--- a/content/en/docs/build/configuration.md
+++ b/content/en/docs/build/configuration.md
@@ -2,39 +2,43 @@
 title: "Configuration"
 draft: false
 ---
-
 <!--
 Copyright The Shipwright Contributors
 
 SPDX-License-Identifier: Apache-2.0
 -->
-
 ## Controller Settings
 
-The controller is installed into Kubernetes with reasonable defaults. However, there are some settings that can be overridden using environment variables in [`controller.yaml`](https://github.com/shipwright-io/build/blob/v0.10.0/deploy/500-controller.yaml).
+The controller is installed into Kubernetes with reasonable defaults. However, there are some settings that can be overridden using environment variables in [`controller.yaml`](../deploy/500-controller.yaml).
 
 The following environment variables are available:
 
 | Environment Variable | Description |
 | --- | --- |
-| `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. |
-| `REMOTE_ARTIFACTS_CONTAINER_IMAGE` | Specify the container image used for the `.spec.sources` remote artifacts download, by default it uses `busybox:latest`. |
-| `GIT_CONTAINER_TEMPLATE` | JSON representation of a [Container](https://pkg.go.dev/k8s.io/api/core/v1#Container) template that is used for steps that clone a Git repository. Default is `{"image":"ghcr.io/shipwright-io/build/git:latest", "command":["/ko-app/git"], "securityContext":{"runAsUser":1000,"runAsGroup":1000}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `CTX_TIMEOUT` | Override the default context timeout used for all Custom Resource Definition reconciliation operations. Default is 5 (seconds). |
+| `REMOTE_ARTIFACTS_CONTAINER_IMAGE` | Specify the container image used for the `.spec.sources` remote artifacts download, by default it uses `quay.io/quay/busybox:latest`. |
+| `TERMINATION_LOG_PATH` | Path of the termination log. This is where controller application will write the reason of its termination. Default value is `/dev/termination-log`. |
+| `GIT_ENABLE_REWRITE_RULE` | Enable Git wrapper to setup a URL `insteadOf` Git config rewrite rule for the respective source URL hostname. Default is `false`. |
+| `GIT_CONTAINER_TEMPLATE` | JSON representation of a [Container] template that is used for steps that clone a Git repository. Default is `{"image": "ghcr.io/shipwright-io/build/git:latest", "command": ["/ko-app/git"], "env": [{"name": "HOME", "value": "/shared-home"}], "securityContext":{"allowPrivilegeEscalation": false, "capabilities": {"drop": ["ALL"]}, "runAsUser": 1000,"runAsGroup": 1000}}` [^1]. The following properties are ignored as they are set by the controller: `args`, `name`. |
 | `GIT_CONTAINER_IMAGE` | Custom container image for Git clone steps. If `GIT_CONTAINER_TEMPLATE` is also specifying an image, then the value for `GIT_CONTAINER_IMAGE` has precedence. |
-| `MUTATE_IMAGE_CONTAINER_TEMPLATE` | JSON representation of a [Container](https://pkg.go.dev/k8s.io/api/core/v1#Container) template that is used for steps that mutates an image if a `Build` has annotations or labels defined in the output. Default is `{"image": "ghcr.io/shipwright-io/build/mutate-image:latest", "command": ["/ko-app/mutate-image"], "env": [{"name": "HOME","value": "/tekton/home"}], "securityContext": {"runAsUser": 0, "capabilities": {"add": ["DAC_OVERRIDE"]}}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
-| `MUTATE_IMAGE_CONTAINER_IMAGE` | Custom container image that is used for steps that mutates an image if a `Build` has annotations or labels defined in the output. If `MUTATE_IMAGE_CONTAINER_TEMPLATE` is also specifying an image, then the value for `MUTATE_IMAGE_CONTAINER_IMAGE` has precedence. |
+| `BUNDLE_IMAGE_CONTAINER_TEMPLATE` | JSON representation of a [Container] template that is used for steps that pulls a bundle image to obtain the packaged source code. Default is `{"image": "ghcr.io/shipwright-io/build/bundle:latest", "command": ["/ko-app/bundle"], "env": [{"name": "HOME","value": "/shared-home"}], "securityContext":{"allowPrivilegeEscalation": false, "capabilities": {"drop": ["ALL"]}, "runAsUser":1000,"runAsGroup":1000}}` [^1]. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `BUNDLE_IMAGE_CONTAINER_IMAGE` | Custom container image that pulls a bundle image to obtain the packaged source code. If `BUNDLE_IMAGE_CONTAINER_TEMPLATE` is also specifying an image, then the value for `BUNDLE_IMAGE_CONTAINER_IMAGE` has precedence. |
+| `IMAGE_PROCESSING_CONTAINER_TEMPLATE` | JSON representation of a [Container](https://pkg.go.dev/k8s.io/api/core/v1#Container) template that is used for steps that processes the image. Default is `{"image": "ghcr.io/shipwright-io/build/image-processing:latest", "command": ["/ko-app/image-processing"], "env": [{"name": "HOME","value": "/shared-home"}], "securityContext": {"allowPrivilegeEscalation": false, "capabilities": {"add": ["DAC_OVERRIDE"], "drop": ["ALL"]}, "runAsUser": 0, "runAsgGroup": 0}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `IMAGE_PROCESSING_CONTAINER_IMAGE` | Custom container image that is used for steps that processes the image. If `IMAGE_PROCESSING_CONTAINER_TEMPLATE` is also specifying an image, then the value for `IMAGE_PROCESSING_CONTAINER_IMAGE` has precedence. |
+| `WAITER_IMAGE_CONTAINER_TEMPLATE` | JSON representation of a [Container] template that waits for local source code to be uploaded to it. Default is `{"image":"ghcr.io/shipwright-io/build/waiter:latest", "command": ["/ko-app/waiter"], "args": ["start"], "env": [{"name": "HOME","value": "/shared-home"}], "securityContext":{"allowPrivilegeEscalation": false, "capabilities": {"drop": ["ALL"]}, "runAsUser":1000,"runAsGroup":1000}}`. The following properties are ignored as they are set by the controller: `args`, `name`. |
+| `WAITER_IMAGE_CONTAINER_IMAGE` | Custom container image that waits for local source code to be uploaded to it. If `WAITER_IMAGE_CONTAINER_TEMPLATE` is also specifying an image, then the value for `WAITER_IMAGE_CONTAINER_IMAGE` has precedence. |
 | `BUILD_CONTROLLER_LEADER_ELECTION_NAMESPACE` |  Set the namespace to be used to store the `shipwright-build-controller` lock, by default it is in the same namespace as the controller itself. |
 | `BUILD_CONTROLLER_LEASE_DURATION` |  Override the `LeaseDuration`, which is the duration that non-leader candidates will wait to force acquire leadership. |
 | `BUILD_CONTROLLER_RENEW_DEADLINE` |  Override the `RenewDeadline`, which is the duration that the acting leader will retry refreshing leadership before giving up. |
 | `BUILD_CONTROLLER_RETRY_PERIOD` |  Override the `RetryPeriod`, which is the duration the LeaderElector clients should wait between tries of actions. |
-| `BUILD_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the build controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `BUILDRUN_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the buildrun controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `BUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the buildstrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `CLUSTERBUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the clusterbuildstrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options](https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options). Default is 0. |
-| `KUBE_API_BURST` | Burst to use for the Kubernetes API client. See [Config.Burst](https://pkg.go.dev/k8s.io/client-go/rest#Config.Burst). A value of 0 or lower will use the default from client-go, which currently is 10. Default is 0. |
-| `KUBE_API_QPS` | QPS to use for the Kubernetes API client. See [Config.QPS](https://pkg.go.dev/k8s.io/client-go/rest#Config.QPS). A value of 0 or lower will use the default from client-go, which currently is 5. Default is 0. |
-| `TERMINATION_LOG_PATH` | Path of the termination log. This is where controller application will write the reason of its termination. Default value is `/dev/termination-log`. |
-| `GIT_ENABLE_REWRITE_RULE` | Enable Git wrapper to setup a URL `insteadOf` Git config rewrite rule for the respective source URL hostname. Default is `false`. |
+| `BUILD_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the build controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `BUILDRUN_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the BuildRun controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `BUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the BuildStrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `CLUSTERBUILDSTRATEGY_MAX_CONCURRENT_RECONCILES` | The number of concurrent reconciles by the ClusterBuildStrategy controller. A value of 0 or lower will use the default from the [controller-runtime controller Options]. Default is 0. |
+| `KUBE_API_BURST` | Burst to use for the Kubernetes API client. See [Config.Burst]. A value of 0 or lower will use the default from client-go, which currently is 10. Default is 0. |
+| `KUBE_API_QPS` | QPS to use for the Kubernetes API client. See [Config.QPS]. A value of 0 or lower will use the default from client-go, which currently is 5. Default is 0. |
+
+[^1]: The `runAsUser` and `runAsGroup` are dynamically overwritten depending on the build strategy that is used. See [Security Contexts](buildstrategies.md#security-contexts) for more information.
 
 ## Role-based Access Control
 
@@ -43,11 +47,19 @@ The following roles are installed:
 
 - `shpwright-build-aggregate-view`: this role grants read access (get, list, watch) to most Shipwright Build objects.
   This includes `BuildStrategy`, `ClusterBuildStrategy`, `Build`, and `BuildRun` objects.
-  This role is aggregated to the [Kubernetes "view" role](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings).
+  This role is aggregated to the [Kubernetes "view" role].
 - `shipwright-build-aggregate-edit`: this role grants write access (create, update, patch, delete) to Shipwright objects that are namespace-scoped.
   This includes `BuildStrategy`, `Builds`, and `BuildRuns`.
   Read access is granted to all `ClusterBuildStrategy` objects.
-  This role is aggregated to the [Kubernetes "edit" and "admin" roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings).
+  This role is aggregated to the [Kubernetes "edit" and "admin" roles].
 
 Only cluster administrators are granted write access to `ClusterBuildStrategy` objects.
-This can be changed by creating a separate [Kubernetes `ClusterRole`](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole) with these permissions and binding the role to appropriate users.
+This can be changed by creating a separate [Kubernetes `ClusterRole`] with these permissions and binding the role to appropriate users.
+
+[Container]:https://pkg.go.dev/k8s.io/api/core/v1#Container
+[controller-runtime controller Options]:https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/controller#Options
+[Config.Burst]:https://pkg.go.dev/k8s.io/client-go/rest#Config.Burst
+[Config.QPS]:https://pkg.go.dev/k8s.io/client-go/rest#Config.QPS
+[Kubernetes "view" role]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+[Kubernetes "edit" and "admin" roles]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#default-roles-and-role-bindings
+[Kubernetes `ClusterRole`]:https://kubernetes.io/docs/reference/access-authn-authz/rbac/#role-and-clusterrole

--- a/content/en/docs/build/metrics.md
+++ b/content/en/docs/build/metrics.md
@@ -2,6 +2,11 @@
 title: Build Controller Metrics
 linkTitle: Metrics
 ---
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
 
 The Build component exposes several metrics to help you monitor the health and behavior of your build resources.
 

--- a/content/en/docs/build/profiling.md
+++ b/content/en/docs/build/profiling.md
@@ -2,6 +2,11 @@
 title: Build Controller Profiling
 linkTitle: Profiling
 ---
+<!--
+Copyright The Shipwright Contributors
+
+SPDX-License-Identifier: Apache-2.0
+-->
 
 The build controller supports a `pprof` profiling mode, which is omitted from the binary by default. To use the profiling, use the controller image that was built with `pprof` enabled.
 


### PR DESCRIPTION
# Changes
Syncs the content/en/docs/* content per shipwright.io/build/docs

Fixes #74 

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```
