### PR TITLE
I recently noticed that some links in the Shipwright documentation were pointing to 404 error pages.

### DIFF
--- a/content/en/docs/build/buildstrategies.md
+++ b/content/en/docs/build/buildstrategies.md
@@ -54,17 +54,17 @@ A `ClusterBuildStrategy` is available cluster-wide, while a `BuildStrategy` is a
 
 ## Available ClusterBuildStrategies
 
-Well-known strategies can be bootstrapped from [here](../samples/v1beta1/buildstrategy). The currently supported Cluster BuildStrategy are:
+Well-known strategies can be bootstrapped from [here](https://github.com/shipwright-io/build/tree/main/samples/v1beta1/buildstrategy). The currently supported Cluster BuildStrategy are:
 
 | Name | Supported platforms |
 | ---- | ------------------- |
-| [buildah](../samples/v1beta1/buildstrategy/buildah) | all |
-| [BuildKit](../samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml) | all |
-| [buildpacks-v3-heroku](../samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml) | linux/amd64 only |
-| [buildpacks-v3](../samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml) | linux/amd64 only |
+| [buildah](https://github.com/shipwright-io/build/tree/main/samples/v1beta1/buildstrategy/buildah) | all |
+| [BuildKit](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/buildkit/buildstrategy_buildkit_cr.yaml) | all |
+| [buildpacks-v3-heroku](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_cr.yaml) | linux/amd64 only |
+| [buildpacks-v3](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_cr.yaml) | linux/amd64 only |
 | [kaniko](../samples/v1beta1/buildstrategy/kaniko/buildstrategy_kaniko_cr.yaml) | all |
-| [ko](../samples/v1beta1/buildstrategy/ko/buildstrategy_ko_cr.yaml) | all |
-| [source-to-image](../samples/v1beta1/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml) | linux/amd64 only |
+| [ko](https://github.com/shipwright-io/build/tree/main/samples/v1beta1/buildstrategy/kaniko) | all |
+| [source-to-image](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/source-to-image/buildstrategy_source-to-image_cr.yaml) | linux/amd64 only |
 
 ## Available BuildStrategies
 
@@ -72,8 +72,8 @@ The current supported namespaces BuildStrategy are:
 
 | Name | Supported platforms |
 | ---- | ------------------- |
-| [buildpacks-v3-heroku](../samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml) | linux/amd64 only |
-| [buildpacks-v3](../samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml) | linux/amd64 only |
+| [buildpacks-v3-heroku](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3-heroku_namespaced_cr.yaml) | linux/amd64 only |
+| [buildpacks-v3](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/buildpacks-v3/buildstrategy_buildpacks-v3_namespaced_cr.yaml) | linux/amd64 only |
 
 ---
 
@@ -83,8 +83,8 @@ The `buildah` ClusterBuildStrategy uses [`buildah`](https://github.com/container
 
 The strategy is available in two formats:
 
-- [`buildah-shipwright-managed-push`](../samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push%20copy_cr.yaml)
-- [`buildah-strategy-managed-push`](../samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml)
+- [`buildah-shipwright-managed-push`](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml)
+- [`buildah-strategy-managed-push`](https://github.com/shipwright-io/build/blob/main/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_strategy_managed_push_cr.yaml)
 
 Learn more about the differences of [shipwright-, or strategy-managed push](#output-directory-vs-output-image)
 


### PR DESCRIPTION
I recently noticed that some links in the Shipwright documentation were pointing to 404 error pages, particularly in the sections for BuildStrategies and ClusterBuildStrategies. To resolve this issue, I made the following changes:

Updated the links to point to the correct files in the GitHub repository.
Ensured that both ClusterBuildStrategies and BuildStrategies sections now have accurate links to help users easily navigate to the relevant strategies.
For example, in the ClusterBuildStrategies section, I replaced the outdated relative links like ../samples/v1beta1/buildstrategy with the correct absolute links such as https://github.com/shipwright-io/build/tree/main/samples/v1beta1/buildstrategy.

This should make it easier for users to access the correct documentation without encountering broken links. Let me know if you have any questions or suggestions on further improvements!

Thanks,
Shivam Jaiswal

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->
In the original doumentation of Shipwright it was difficult to find about the files of BuildStrategies and ClusterBuildStrategies.
I have added the correct links in their place.
# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
Bug fixes
<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->
