### PR TITLE
Direct installation requires `--server-side=true`

### DIFF
--- a/content/en/docs/getting-started/installation.md
+++ b/content/en/docs/getting-started/installation.md
@@ -57,7 +57,7 @@ We also publish a Kubernetes manifest that installs Shipwright directly into the
 Applying this manifest requires cluster administrator permissions:
 
 ```bash
-$ kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/release.yaml
+$ kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/release.yaml --server-side=true
 ```
 
 ## Installing Sample Build Strategies


### PR DESCRIPTION
The command:

```bash
kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/release.yaml
```
Will fail with the error:
`The CustomResourceDefinition "buildruns.shipwright.io" is invalid: metadata.annotations: Too long: must have at most 262144 bytes`

This commit updates 

Similar to shipwright-io/build#1315.

# Changes

Update the the documentation to include the flag `--server-side=true` when installing Shipwright build directly from the manifest.

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes
```release-note
NONE
```