### PR TITLE
v0.14.0 Operator Release

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -37,7 +37,7 @@ Shipwright supports popular tools such as
 
 {{% blocks/feature icon="fa-ship" title="Release v0.14.0 Available!" %}}
 
-Our latest release is now available on GitHub (<a href="https://github.com/shipwright-io/build/releases/tag/v0.14.0">Build Controller</a>, <a href="https://github.com/shipwright-io/cli/releases/tag/v0.14.0" target="_blank">CLI</a><!--, and <a href="https://github.com/shipwright-io/operator/releases/tag/v0.13.0">Operator</a>-->).
+Our latest release is now available on GitHub (<a href="https://github.com/shipwright-io/build/releases/tag/v0.14.0">Build Controller</a>, <a href="https://github.com/shipwright-io/cli/releases/tag/v0.14.0" target="_blank">CLI</a> and <a href="https://github.com/shipwright-io/operator/releases/tag/v0.14.0">Operator</a>).
 Read more in our <a href="/blog/2024/11/14/shipwright-v0.14.0-is-here/">blog post</a>.
 
 {{% /blocks/feature %}}

--- a/content/en/blog/posts/2024-11-15-release-v0.14.0.md
+++ b/content/en/blog/posts/2024-11-15-release-v0.14.0.md
@@ -5,6 +5,8 @@ draft: false
 author: "Sascha Schwarze ([@SaschaSchwarze0](https://github.com/SaschaSchwarze0))"
 ---
 
+_Update 2025-01-07: added Operator installation instructions_
+
 We are happy to announce the v0.14.0 release of Shipwright. This is our first release since we have joined the [Cloud Native Computing Foundation (CNCF)](https://www.cncf.io/projects/shipwright/) as a sandbox project.
 
 In this release, we have put together some nice features:
@@ -84,4 +86,20 @@ shp help
 curl --silent --fail --location "https://github.com/shipwright-io/cli/releases/download/v0.14.0/cli_0.14.0_linux_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | sudo tar -xzf - -C /usr/bin shp
 shp version
 shp help
+```
+
+### Operator
+
+To deploy and manage Shipwright Builds in your cluster, first ensure the operator v0.14.0 is installed and running on your cluster. You can follow the instructions on [OperatorHub](https://operatorhub.io/operator/shipwright-operator).
+
+Next, create the following:
+
+```yaml
+---
+apiVersion: operator.shipwright.io/v1alpha1
+kind: ShipwrightBuild
+metadata:
+  name: shipwright-operator
+spec:
+  targetNamespace: shipwright-build
 ```

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -97,7 +97,7 @@ params:
   # The version number for the version of the docs represented in this doc set.
   # Used in the "version-banner" partial to display a version number for the
   # current doc set.
-  version: v0.13.0
+  version: v0.14.0
 
   # A link to latest version of the docs. Used in the "version-banner" partial to
   # point people to the main doc site.


### PR DESCRIPTION
# Changes

Update release blog post and front page to announce that the v0.14.0 operator has (finally) been released.

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Add instructions on how to install Shipwright v0.14.0 using the operator
```
