### PR TITLE
feat: Announce v0.15.z Releases

### DIFF
--- a/content/en/blog/posts/2025-02-28-release-v0.15.md
+++ b/content/en/blog/posts/2025-02-28-release-v0.15.md
@@ -1,0 +1,122 @@
+---
+title: "Shipwright v0.15 Is Here"
+date: 2025-03-03T15:20:41-05:00
+draft: false
+author: "Adam Kaplan ([@adambkaplan](https://github.com/adambkaplan))"
+---
+
+We are happy to announce the latest release of Shipwright's main projects - `v0.15.z`.
+You may have noticed the usual ".0" in the version has been replaced with a ".z" - more on this in
+a minute!
+
+## Key Features
+
+Below are the key features in this release:
+
+### Build: More Control for Node Scheduling
+
+Builds v0.15 adds additional support for controlling which nodes a build can run on.
+In addition to specifying a node selector (introduced in [v0.14]({{< ref 2024-11-15-release-v0.14.0.md >}})), builds can now tolerate node
+taints and instruct Kubernetes to use a custom pod scheduler. The latter feature can be used
+with new projects like [Volcano](https://volcano.sh/en/), which optimizes pod scheduling for batch
+workloads.
+
+### CLI: Maintenance Update
+
+The CLI was updated to support Build v0.15.0 APIs.
+
+### Operator: Builds Upgrade
+
+The operator was updated to deploy Builds v0.15.2.
+
+## Installing Shipwright
+
+### Build
+
+1. Install Tekton v0.68.0:
+
+   ```bash
+   kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.68.0/release.yaml
+   ```
+
+2. Install v0.15.2 using the release YAML manifest:
+
+   ```bash
+   kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.15.2/release.yaml --server-side
+
+   curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/v0.15.2/hack/setup-webhook-cert.sh | bash
+   ```
+
+3. (Optionally) Install the sample build strategies using the YAML manifest:
+
+   ```bash
+   kubectl apply --filename https://github.com/shipwright-io/build/releases/download/v0.15.2/sample-strategies.yaml --server-side
+   ```
+
+### CLI
+
+#### Windows
+
+```sh
+curl --silent --fail --location https://github.com/shipwright-io/cli/releases/download/v0.15.0/cli_0.15.0_windows_x86_64.tar.gz | tar xzf - shp.exe
+shp version
+shp help
+```
+
+#### Mac
+
+```sh
+curl --silent --fail --location https://github.com/shipwright-io/cli/releases/download/v0.15.0/cli_0.15.0_macOS_$(uname -m).tar.gz | tar -xzf - -C /usr/local/bin shp
+shp version
+shp help
+```
+
+#### Linux
+
+```sh
+curl --silent --fail --location "https://github.com/shipwright-io/cli/releases/download/v0.15.0/cli_0.15.0_linux_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | sudo tar -xzf - -C /usr/bin shp
+shp version
+shp help
+```
+
+### Operator
+
+To deploy and manage Shipwright Builds in your cluster, first ensure the operator v0.15.2 is
+installed and running on your cluster. You can follow the instructions on
+[OperatorHub](https://operatorhub.io/operator/shipwright-operator).
+
+Next, create the following:
+
+```yaml
+---
+apiVersion: operator.shipwright.io/v1alpha1
+kind: ShipwrightBuild
+metadata:
+  name: shipwright-operator
+spec:
+  targetNamespace: shipwright-build
+```
+
+
+## What About That .z?
+
+Since v0.14.0 was released, we have done a lot of work behind the scenes to automate Shipwright's
+release process and security posture. Part of this includes a set of
+[nightly GitHub Actions](https://github.com/shipwright-io/build/blob/main/.github/workflows/report-release-vulnerabilities.yaml)
+that scan our container images for vulnerabilities at the code and operating system level. 
+This process covers our most recent release as well as the nightly builds that come out of the
+`main` branch.
+
+Less than a day after Builds v0.15.0 was released, vulnerabilties in the `golang.org/x/crypto`
+and `golang.org/x/oauth2` packages were disclosed. These were picked up by our nightly automation,
+which filed a [GitHub issue](https://github.com/shipwright-io/build/issues/1810) notifying the
+community of the problem. The maintainers quickly sprung into action, submitting pull requests to
+patch the vulnerable code. The next night our automation detected these vulnerabilities were fixed,
+and drafted a security patch release. 
+
+Two days later, we patched the Build project [all over again](https://github.com/shipwright-io/build/issues/1817).
+All this happened as the `cli` and `operator` projects were preparing releases of their own.
+
+Special thank you to [@SaschaSchwarze0](https://github.com/SaschaSchwarze0) for not only fixing
+these vulnerabilties, but also building much of the workflows that automate these security
+updates. Bravo!

--- a/content/en/blog/posts/2025-02-28-release-v0.15.md
+++ b/content/en/blog/posts/2025-02-28-release-v0.15.md
@@ -58,7 +58,7 @@ The operator was updated to deploy Builds v0.15.2.
 #### Windows
 
 ```sh
-curl --silent --fail --location https://github.com/shipwright-io/cli/releases/download/v0.15.0/cli_0.15.0_windows_x86_64.tar.gz | tar xzf - shp.exe
+curl --silent --fail --location https://github.com/shipwright-io/cli/releases/download/v0.15.0/shp_0.15.0_windows_x86_64.tar.gz | tar xzf - shp.exe
 shp version
 shp help
 ```
@@ -66,7 +66,7 @@ shp help
 #### Mac
 
 ```sh
-curl --silent --fail --location https://github.com/shipwright-io/cli/releases/download/v0.15.0/cli_0.15.0_macOS_$(uname -m).tar.gz | tar -xzf - -C /usr/local/bin shp
+curl --silent --fail --location https://github.com/shipwright-io/cli/releases/download/v0.15.0/shp_0.15.0_macOS_$(uname -m).tar.gz | tar -xzf - -C /usr/local/bin shp
 shp version
 shp help
 ```
@@ -74,7 +74,7 @@ shp help
 #### Linux
 
 ```sh
-curl --silent --fail --location "https://github.com/shipwright-io/cli/releases/download/v0.15.0/cli_0.15.0_linux_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | sudo tar -xzf - -C /usr/bin shp
+curl --silent --fail --location "https://github.com/shipwright-io/cli/releases/download/v0.15.0/shp_0.15.0_linux_$(uname -m | sed 's/aarch64/arm64/').tar.gz" | sudo tar -xzf - -C /usr/bin shp
 shp version
 shp help
 ```


### PR DESCRIPTION
# Changes

Blog post announcing v0.15.z releases for Shipwright. This includes a note on the Build v0.15.1 release, and how it was issued so quickly.

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Blog post for v0.15 releases
```
