### PR TITLE
Update main page links to point to v0.15

### DIFF
--- a/content/en/_index.html
+++ b/content/en/_index.html
@@ -36,11 +36,11 @@ linkTitle = "Shipwright"
 {{% blocks/feature icon="fab" %}}
 {{% /blocks/feature %}}
 
-{{% blocks/feature icon="fa-ship" title="Release v0.14.0 Available!" %}}
+{{% blocks/feature icon="fa-ship" title="Release v0.15 Available!" %}}
 
 <p>
-Our latest release is now available on GitHub (<a href="https://github.com/shipwright-io/build/releases/tag/v0.14.0">Build Controller</a>, <a href="https://github.com/shipwright-io/cli/releases/tag/v0.14.0" target="_blank">CLI</a> and <a href="https://github.com/shipwright-io/operator/releases/tag/v0.14.0">Operator</a>).
-Read more in our <a href="/blog/2024/11/14/shipwright-v0.14.0-is-here/">blog post</a>.
+Our latest release is now available on GitHub (<a href="https://github.com/shipwright-io/build/releases/tag/v0.15.2">Build Controller</a>, <a href="https://github.com/shipwright-io/cli/releases/tag/v0.15.0" target="_blank">CLI</a> and <a href="https://github.com/shipwright-io/operator/releases/tag/v0.15.2">Operator</a>).
+Read more in our <a href="/blog/2025/03/03/shipwright-v0.15-is-here/">blog post</a>.
 </p>
 
 {{% /blocks/feature %}}


### PR DESCRIPTION
# Changes

Updating the main page of our website to point to the v0.15 releases

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
