### PR TITLE
fix: Remove Docsy Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "themes/docsy"]
-	path = themes/docsy
-	url = https://github.com/google/docsy.git

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ You can run the website locally using the Hugo static site generator.
 
 To use this repository, you need the following installed locally:
 
-* npm - this can be obtained by installing [Node.js](https://nodejs.org/en/download/) on your system
+* `npm` - this can be obtained by installing [Node.js](https://nodejs.org/en/download/) on your system.
 * [Hugo](https://gohugo.io/getting-started/installing/) - be sure to install the **extended version**.
-* [Ruby](https://www.ruby-lang.org/en/)
+* [Go SDK](https://go.dev/doc/install) v1.21 or higher.
 
 Once installed, clone the repository and navigate to the directory:
 
 ```bash
-$ git clone --recurse-submodules --depth 1 https://github.com/shipwright-io/website.git
+$ git clone https://github.com/shipwright-io/website.git
 $ cd website
 ```
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,9 @@ publish="public/"
 command="make netlify"
 
 [build.environment]
-HUGO_VERSION="0.113.0"
+HUGO_VERSION = "0.145.0"
+NODE_VERSION = "22"
+GO_VERSION = "1.23.4"
 
 [context.deploy-preview]
 command="make netlify-preview"


### PR DESCRIPTION
# Changes

Remove the docsy theme submodule. This has been replaced by Hugo's module system, which requires the golang SDK to be installed on the writer's computer.

Also update the build dependencies in our Netlify environment.

Fixes #158

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
action required: Removed git submodule with Docsy theme. This has been replaced by Hugo's module system.
```
