### PR TITLE
Correct links on documentation page

### DIFF
--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -129,5 +129,5 @@ running `Pod`. See [`BuildRun`](/docs/build/buildrun/) for more details.
 
 - [Configuration](/docs/build/configuration/)
 - Build controller observability
-  - [Metrics](/docs/metrics/)
-  - [Profiling](/docs/profiling/)
+  - [Metrics](/docs/build/metrics/)
+  - [Profiling](/docs/build/profiling/)

--- a/content/en/docs/_index.md
+++ b/content/en/docs/_index.md
@@ -127,7 +127,7 @@ running `Pod`. See [`BuildRun`](/docs/build/buildrun/) for more details.
 
 ## Further reading
 
-- [Configuration](/docs/configuration/)
+- [Configuration](/docs/build/configuration/)
 - Build controller observability
   - [Metrics](/docs/metrics/)
   - [Profiling](/docs/profiling/)


### PR DESCRIPTION
# Changes

- Correct links in "Further reading" paragraph
- The directory "build" was missing in the path

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [ ] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```