### PR TITLE
fix: Remove Docsy from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,6 @@ install: ## install dependencies
 	npm install
 	hugo mod get
 	hugo mod graph
-	hugo mod get github.com/google/docsy
 
 .PHONY: netlify
 netlify:
@@ -33,11 +32,11 @@ netlify-preview: ## build a preview of the site for Netlify
 
 .PHONY: serve
 serve: ## serve the content locally for testing
-	hugo -t docsy server
+	hugo server
 
 .PHONY: serve-preview
 serve-preview: ## serve the preview content locally for testing
-	hugo -t docsy server -F
+	hugo server -F
 
 .PHONY: bin-dir
 bin-dir: ## Creates a local "bin" directory for helper applications.


### PR DESCRIPTION
# Changes

Remove references to Docsy, since we are now using the lotusdocs theme.

/kind bug

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
fix: Remove references to docsy in make commands
```

