### PR TITLE
fix: Update Tekton Manifests URL

### DIFF
--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -14,7 +14,7 @@ with our operator.
 - [Tekton pipelines](https://tekton.dev/docs/installation/) v0.68 or later.
 
   ```bash
-  kubectl apply --filename https://storage.googleapis.com/tekton-releases/pipeline/latest/release.yaml
+  kubectl apply --filename https://infra.tekton.dev/tekton-releases/pipeline/latest/release.yaml
   ```
 
 ## Installing Shipwright Builds with the Operator


### PR DESCRIPTION
# Changes

Update Tekton artifact hosting to `infra.tekton.dev`

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Update Tekton manifest host to `infra.tekton.dev`
```