### PR TITLE
Document runtimeClassName field in API reference

### DIFF
--- a/content/docs/build/build.md
+++ b/content/docs/build/build.md
@@ -24,6 +24,7 @@ A `Build` resource allows the user to define:
 - nodeSelector
 - tolerations
 - schedulerName
+- runtimeClassName
 
 A `Build` is available within a namespace.
 
@@ -81,6 +82,7 @@ To prevent users from triggering `BuildRun`s (_execution of a Build_) that will 
 | NodeSelectorNotValid                            | The specified nodeSelector is not valid. |
 | TolerationNotValid                              | The specified tolerations are not valid. |
 | SchedulerNameNotValid                              | The specified schedulerName is not valid. |
+| RuntimeClassNameNotValid                           | The specified runtimeClassName is not valid. |
 
 ## Configuring a Build
 
@@ -115,6 +117,7 @@ The `Build` definition supports the following fields:
   - `spec.nodeSelector` - Specifies a selector which must match a node's labels for the build pod to be scheduled on that node. If nodeSelectors are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.tolerations` - Specifies the tolerations for the build pod. Only `key`, `value`, and `operator` are supported. Only `NoSchedule` taint `effect` is supported. If tolerations are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.schedulerName` - Specifies the scheduler name for the build pod. If schedulerName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
+  - `spec.runtimeClassName` - Specifies the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) to be used to run the build pod with an alternative container runtime. If runtimeClassName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
 
 ### Defining the Source
 

--- a/content/docs/build/buildrun.md
+++ b/content/docs/build/buildrun.md
@@ -79,6 +79,7 @@ The `BuildRun` definition supports the following fields:
   - `spec.nodeSelector` - Specifies a selector which must match a node's labels for the build pod to be scheduled on that node. If nodeSelectors are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.tolerations` - Specifies the tolerations for the build pod. Only `key`, `value`, and `operator` are supported. Only `NoSchedule` taint `effect` is supported. If tolerations are specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
   - `spec.schedulerName` - Specifies the scheduler name for the build pod. If schedulerName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
+  - `spec.runtimeClassName` - Specifies the [RuntimeClass](https://kubernetes.io/docs/concepts/containers/runtime-class/) to be used to run the build pod with an alternative container runtime. If runtimeClassName is specified in both a `Build` and `BuildRun`, `BuildRun` values take precedence.
 
 **Note**: The `spec.build.name` and `spec.build.spec` are mutually exclusive. Furthermore, the overrides for `timeout`, `paramValues`, `output`, and `env` can only be combined with `spec.build.name`, but **not** with `spec.build.spec`.
 

--- a/content/docs/ref/api/build.md
+++ b/content/docs/ref/api/build.md
@@ -126,6 +126,7 @@ _Appears in:_
 | `NodeSelectorNotValid` | NodeSelectorNotValid indicates that the nodeSelector value is not valid<br /> |
 | `TolerationNotValid` | TolerationNotValid indicates that the Toleration value is not valid<br /> |
 | `SchedulerNameNotValid` | SchedulerNameNotValid indicates that the Scheduler name is not valid<br /> |
+| `RuntimeClassNameNotValid` | RuntimeClassNameNotValid indicates that the RuntimeClassName is not valid<br /> |
 
 
 ### BuildRetention
@@ -260,6 +261,7 @@ _Appears in:_
 | `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is a selector which must be true for the pod to fit on a node.<br />Selector which must match a node's labels for the pod to be scheduled on that node.<br />More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |  |  |
 | `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#toleration-v1-core) array_ | If specified, the pod's tolerations. |  |  |
 | `schedulerName` _string_ | SchedulerName specifies the scheduler to be used to dispatch the Pod |  |  |
+| `runtimeClassName` _string_ | RuntimeClassName specifies the RuntimeClass to be used to run the Pod |  |  |
 
 
 ### BuildRunStatus
@@ -332,6 +334,7 @@ _Appears in:_
 | `nodeSelector` _object (keys:string, values:string)_ | NodeSelector is a selector which must be true for the pod to fit on a node.<br />Selector which must match a node's labels for the pod to be scheduled on that node.<br />More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |  |  |
 | `tolerations` _[Toleration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.3/#toleration-v1-core) array_ | If specified, the pod's tolerations. |  |  |
 | `schedulerName` _string_ | SchedulerName specifies the scheduler to be used to dispatch the Pod |  |  |
+| `runtimeClassName` _string_ | RuntimeClassName specifies the RuntimeClass to be used to run the Pod |  |  |
 
 
 ### BuildStatus


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->
Document the new `runtimeClassName` field added in shipwright-io/build#2079

Fixes #183 

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!--
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

For pull requests with a release note:

```release-note
Your release note here
```

For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:

```release-note
action required: your release note here
```

For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:

```release-note
NONE
```
-->

```release-note
NONE
```