### PR TITLE
feat: add missing instructions for manual installation

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -59,6 +59,15 @@ Applying this manifest requires cluster administrator permissions:
 $ kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/release.yaml --server-side=true
 ```
 
+Run the following two scripts (also requires cluster administrator permissions)
+to setup the webhook certificate and migrate the storage if required.
+
+ ```bash $
+$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/latest/hack/setup-webhook-cert.sh | bash
+
+$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/latest/hack/storage-version-migration.sh | bash
+```
+
 ## Installing Sample Build Strategies
 
 The Shipwright community maintains a curated set of build strategies for popular build tools.


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here. Ideally you can get that description straight from
your descriptive commit message(s)! -->

This PR adds missing instructions for the manual installation in the getting started guide.
The manifest is not enough, there's also the need for:

- Webhook secret creation
- Storage migration

It's documentated in the build's repository README.

# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Fixes #221

# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug
/kind feature
/kind cleanup
/kind documentation

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

/kind bug

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Kind label has been set
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!-- Describe any user-facing changes here, or mark as NONE.

Examples of user-facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

If this PR requires additional action from users switching to the new release,
include the string "action required" (case insensitive) in the release note.

If there are no user-facing changes, write NONE below. -->

```release-note
Missing instruction for the manual manifest deployment of build have been added
```
