### PR TITLE
fix: correct installation scripts URLs

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -63,10 +63,13 @@ Run the following two scripts (also requires cluster administrator permissions)
 to setup the webhook certificate and migrate the storage if required.
 
  ```bash $
-$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/latest/hack/setup-webhook-cert.sh | bash
+$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/setup-webhook-cert.sh | bash
 
-$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/latest/hack/storage-version-migration.sh | bash
+$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
 ```
+
+If you want to use a specific version of Shipwright, replace latest and main in
+the URLs above with the corresponding tag.
 
 ## Installing Sample Build Strategies
 


### PR DESCRIPTION
The manifests comes from the release but the scripts from the sources.

# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here. Ideally you can get that description straight from
your descriptive commit message(s)! -->
Fix wrong scripts URLs added in #220 

# Related Issue

<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
or "Related to" if the issue needs additional work. -->

Part of #221 

# Type of PR

<!-- Replace with one of the following `/kind` commands so Prow applies the label:

/kind bug
/kind feature
/kind cleanup
/kind documentation

See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->

/kind documentation

# Submitter Checklist

- [X] Includes tests if functionality changed/was added
- [X] Includes docs if changes are user-facing
- [X] Kind label has been set
- [X] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

<!-- Describe any user-facing changes here, or mark as NONE.

Examples of user-facing changes:
- API changes
- Bug fixes
- Any changes in behavior
- Changes requiring upgrade notices or deprecation warnings

If this PR requires additional action from users switching to the new release,
include the string "action required" (case insensitive) in the release note.

If there are no user-facing changes, write NONE below. -->

```release-note
NONE
```
