### PR TITLE
fix: remove shell prompt symbols from installation commands

### DIFF
--- a/docs/build/buildrun.md
+++ b/docs/build/buildrun.md
@@ -320,7 +320,12 @@ spec:
 The `BuildRun` resource is updated as soon as the current image building status changes:
 
 ```bash
-$ kubectl get buildrun buildpacks-v3-buildrun
+kubectl get buildrun buildpacks-v3-buildrun
+```
+
+The output is similar to this:
+
+```text
 NAME                    SUCCEEDED   REASON    MESSAGE   STARTTIME   COMPLETIONTIME
 buildpacks-v3-buildrun  Unknown     Pending   Pending   1s
 ```
@@ -328,7 +333,12 @@ buildpacks-v3-buildrun  Unknown     Pending   Pending   1s
 And finally:
 
 ```bash
-$ kubectl get buildrun buildpacks-v3-buildrun
+kubectl get buildrun buildpacks-v3-buildrun
+```
+
+The output is similar to this:
+
+```text
 NAME                    SUCCEEDED   REASON      MESSAGE                              STARTTIME   COMPLETIONTIME
 buildpacks-v3-buildrun  True        Succeeded   All Steps have completed executing   4m28s       16s
 ```

--- a/docs/build/buildstrategies.md
+++ b/docs/build/buildstrategies.md
@@ -835,7 +835,12 @@ We will see some differences between the `TaskRun` definition and the `pod` defi
 For the `TaskRun`, as expected we can see the resources on each `step`, as we previously define on our [strategy](https://github.com/shipwright-io/build/tree/v0.18.0/samples/v1beta1/buildstrategy/buildah/buildstrategy_buildah_shipwright_managed_push_cr.yaml).
 
 ```sh
-$ kubectl -n test-build get tr buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-bud" ) | .resources'
+kubectl -n test-build get tr buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-bud" ) | .resources'
+```
+
+The output is similar to this:
+
+```json
 {
   "limits": {
     "cpu": "500m",
@@ -846,8 +851,15 @@ $ kubectl -n test-build get tr buildah-golang-buildrun-9gmcx-pod-lhzbc -o json |
     "memory": "65Mi"
   }
 }
+```
 
-$ kubectl -n test-build get tr buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-push" ) | .resources'
+```sh
+kubectl -n test-build get tr buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-push" ) | .resources'
+```
+
+The output is similar to this:
+
+```json
 {
   "limits": {
     "cpu": "500m",
@@ -863,7 +875,12 @@ $ kubectl -n test-build get tr buildah-golang-buildrun-9gmcx-pod-lhzbc -o json |
 The pod definition is different, while Tekton will only use the **highest** values of one container, and set the rest(lowest) to zero:
 
 ```sh
-$ kubectl -n test-build get pods buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-bud" ) | .resources'
+kubectl -n test-build get pods buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-bud" ) | .resources'
+```
+
+The output is similar to this:
+
+```json
 {
   "limits": {
     "cpu": "500m",
@@ -875,8 +892,15 @@ $ kubectl -n test-build get pods buildah-golang-buildrun-9gmcx-pod-lhzbc -o json
     "memory": "65Mi"
   }
 }
+```
 
-$ kubectl -n test-build get pods buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-push" ) | .resources'
+```sh
+kubectl -n test-build get pods buildah-golang-buildrun-9gmcx-pod-lhzbc -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-push" ) | .resources'
+```
+
+The output is similar to this:
+
+```text
 {
   "limits": {
     "cpu": "500m",
@@ -947,7 +971,12 @@ If we apply the following resources:
 For the `TaskRun`, as expected we can see the resources on each `step`.
 
 ```sh
-$ kubectl -n test-build get tr buildah-golang-buildrun-skgrp -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-bud" ) | .resources'
+kubectl -n test-build get tr buildah-golang-buildrun-skgrp -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-bud" ) | .resources'
+```
+
+The output is similar to this:
+
+```json
 {
   "limits": {
     "cpu": "500m",
@@ -958,8 +987,15 @@ $ kubectl -n test-build get tr buildah-golang-buildrun-skgrp -o json | jq '.spec
     "memory": "65Mi"
   }
 }
+```
 
-$ kubectl -n test-build get tr buildah-golang-buildrun-skgrp -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-push" ) | .resources'
+```sh
+kubectl -n test-build get tr buildah-golang-buildrun-skgrp -o json | jq '.spec.taskSpec.steps[] | select(.name == "step-buildah-push" ) | .resources'
+```
+
+The output is similar to this:
+
+```json
 {
   "limits": {
     "cpu": "500m",
@@ -975,7 +1011,12 @@ $ kubectl -n test-build get tr buildah-golang-buildrun-skgrp -o json | jq '.spec
 The pod definition is different, while Tekton will only use the **highest** values of one container, and set the rest(lowest) to zero:
 
 ```sh
-$ kubectl -n test-build get pods buildah-golang-buildrun-95xq8-pod-mww8d -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-bud" ) | .resources'
+kubectl -n test-build get pods buildah-golang-buildrun-95xq8-pod-mww8d -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-bud" ) | .resources'
+```
+
+The output is similar to this:
+
+```text
 {
   "limits": {
     "cpu": "500m",
@@ -987,7 +1028,15 @@ $ kubectl -n test-build get pods buildah-golang-buildrun-95xq8-pod-mww8d -o json
     "memory": "0"                 <------------------- See how the memory is set to ZERO
   }
 }
-$ kubectl -n test-build get pods buildah-golang-buildrun-95xq8-pod-mww8d -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-push" ) | .resources'
+```
+
+```sh
+kubectl -n test-build get pods buildah-golang-buildrun-95xq8-pod-mww8d -o json | jq '.spec.containers[] | select(.name == "step-step-buildah-push" ) | .resources'
+```
+
+The output is similar to this:
+
+```text
 {
   "limits": {
     "cpu": "500m",

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -26,7 +26,7 @@ Before installation, ensure that OLM has been deployed on your cluster by follow
 Once OLM has been deployed, use the following command to install the latest operator release from [operatorhub.io](https://operatorhub.io/operator/shipwright-operator):
 
 ```bash
-$ kubectl apply -f https://operatorhub.io/install/shipwright-operator.yaml
+kubectl apply -f https://operatorhub.io/install/shipwright-operator.yaml
 ```
 
 ### Usage
@@ -56,16 +56,16 @@ We also publish a Kubernetes manifest that installs Shipwright directly into the
 Applying this manifest requires cluster administrator permissions:
 
 ```bash
-$ kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/release.yaml --server-side=true
+kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/release.yaml --server-side=true
 ```
 
 Run the following two scripts (also requires cluster administrator permissions)
 to setup the webhook certificate and migrate the storage if required.
 
- ```bash $
-$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/setup-webhook-cert.sh | bash
+```bash
+curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/setup-webhook-cert.sh | bash
 
-$ curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
+curl --silent --location https://raw.githubusercontent.com/shipwright-io/build/main/hack/storage-version-migration.sh | bash
 ```
 
 If you want to use a specific version of Shipwright, replace latest and main in
@@ -77,5 +77,5 @@ The Shipwright community maintains a curated set of build strategies for popular
 These can be optionally installed after Shipwright Builds has been deployed:
 
 ```bash
-$ kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/sample-strategies.yaml
+kubectl apply -f https://github.com/shipwright-io/build/releases/latest/download/sample-strategies.yaml
 ```


### PR DESCRIPTION
# Changes

Removes the leading `$` shell prompt symbol from bash code blocks in the installation guide. The `$` was being included when users clicked the copy-to-clipboard button, so pasted commands either failed outright or required manually stripping the prompt character first.

Also fixes a stray `` ```bash $ `` fence typo on the webhook-cert setup block.

# Related Issue

Fixes #218

# Type of PR

/kind bug

# Submitter Checklist

- [x] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

# Release Notes

```release-note
NONE
```