### PR TITLE
chore: restore adambkaplan as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,6 @@
 approvers:
 - qu1queee
+- adambkaplan
 - otaviof
 - SaschaSchwarze0
 
@@ -9,7 +10,6 @@ reviewers:
 - rxinui
 
 emeritus_approvers:
-- adambkaplan # 2026-06-17
 - sbose78
 
 emeritus_reviewers:


### PR DESCRIPTION
# Changes

I have changed my mind and would like to remain as an approver on the website repo!

This reverts commit 77564dd3b634f39eabdddda45a96189e277bd4dd, reversing changes made to 7a8769b2357da1d77ddb738d1077a5e4211c30a0.

# Related Issue

N/A
# Type of PR

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] Kind label has been set
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
